### PR TITLE
:poop: Tell allowing insecure content in warning modal

### DIFF
--- a/ui/src/components/SubmitProofRequest.tsx
+++ b/ui/src/components/SubmitProofRequest.tsx
@@ -30,6 +30,7 @@ export function SubmitProofRequest() {
             <WarningModal
               content={[
                 "You are about to submit your proof request to our server. This server is meant to be used for demonstration and development purposes. We haven't run a trusted setup ceremony. This is both a privacy and security issue. Don't use the generated proof results in production or for any sensitive purposes.",
+                "Also you MUST ALLOW INSECURE CONTENT in your browser settings to be able to submit the proof request (because we haven't a TLS certificate for the proving server yet 💩)."
               ]}
             />
             {warningWasRead ? (


### PR DESCRIPTION
Because there is no TLS certificate on dev proving server
