### PR TITLE
:sparkles:(discord-bot) display reference to channel as clickable link

### DIFF
--- a/discord-bot/README.md
+++ b/discord-bot/README.md
@@ -26,5 +26,5 @@
 
 ## Develop
 
-1. Set environment variables (see [.env-sample](../.env-example)
+1. Set environment variables (see [.env-sample](../.env-example))
 2. Install deps: `pnpm --filter discord-bot start.dev`

--- a/discord-bot/src/commands/VerifyCommand.ts
+++ b/discord-bot/src/commands/VerifyCommand.ts
@@ -25,10 +25,10 @@ This is a private channel only visible to you, the bot and the server admins.
 
 1. Visit [anonklub.fly.dev](https://anonklub.fly.dev) to generate a proof. Upon successful proof generation you'll be able to download two files: \`proof.json\` and \`public.json\`
 2. Upload both \`proof.json\` and \`public.json\` files here in this private thread (plus sign >> upload a file). 
-3. Upon successful verification of your prof you'll be granted the \`verified\` role. 10s later, this private channel and your first message in #verification will be deleted.`,
+3. Upon successful verification of your prof you'll be granted the \`verified\` role. 10s later, this private channel and your first message in <#${config.VERIFICATION_CHANNEL_ID}> will be deleted.`,
     })
     await interaction.reply({
-      content: `Hello \`${username}\`, please check #private-verify-${username} for further instructions.`,
+      content: `Hello \`${username}\`, please check <#${privateChannel.id}> for further instructions.`,
     })
   }
 

--- a/discord-bot/src/events/MessageCreate.ts
+++ b/discord-bot/src/events/MessageCreate.ts
@@ -50,7 +50,7 @@ export class MessageCreate extends _Event {
             (pastMessage: Message) =>
               pastMessage.author.id === config.CLIENT_ID &&
               pastMessage.content.includes(
-                `Hello \`${message.author.username}\`, please check #private-verify-${message.author.username} for further instructions.`,
+                `Hello \`${message.author.username}\`, please check <#${message.channel.id}> for further instructions.`,
               ),
           )
           if (botMessage !== undefined) await botMessage.delete()


### PR DESCRIPTION
- :fire:(discord-bot) remove unused `/prove` command (#255)
- :sparkles:(discord-bot) display reference to channel as clickable link
