### PR TITLE
fix: ignore ``@anonklub/merkle-tree` when publishing packages

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -7,5 +7,5 @@
   "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
-  "ignore": []
+  "ignore": ["@anonklub/merkle-tree"]
 }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Install
         run: pnpm --filter="./@anonklub/**" i --ignore-scripts
 
-      - name: Create Release PR Or Release
+      - name: Release
         uses: changesets/action@v1
         with:
           publish: pnpm publish-packages


### PR DESCRIPTION
This is the action that published @anonklub/merkle-tree. https://github.com/anonklub/anonklub/actions/runs/7613894033/job/20734903701#step:8:72

This PR ignores the package for publishing by `changeset` and should therefore prevent further publishing.
We may want to review `publish-packages` or update the GH action so that it always opens a PR instead of directly publishing.

I also unpublished the wrongly published @anonklub/merkle-tree@1.0.0 package