### PR TITLE
feat(ui): display error boundary for segments that fetch data server side

### DIFF
--- a/ui/src/app/query/asset/nft/punk/error.tsx
+++ b/ui/src/app/query/asset/nft/punk/error.tsx
@@ -1,0 +1,27 @@
+'use client'
+import { useEffect } from 'react'
+
+export default function Error({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string }
+  reset: () => void
+}) {
+  useEffect(() => {
+    console.error(error)
+  }, [error])
+
+  return (
+    <div className='bg-gray flex min-h-screen flex-col items-center justify-start pt-32 text-center text-red'>
+      <h2 className='mb-4 text-4xl font-bold'>Something went wrong!</h2>
+      <p className='mb-8 text-red'>{error.message}</p>
+      <button
+        className='focus:shadow-outline transform rounded bg-red px-4 py-2 font-bold text-grey transition-colors duration-150 hover:bg-grey hover:text-red focus:outline-none'
+        onClick={() => reset()}
+      >
+        Try again
+      </button>
+    </div>
+  )
+}

--- a/ui/src/app/query/beacon/error.tsx
+++ b/ui/src/app/query/beacon/error.tsx
@@ -1,0 +1,27 @@
+'use client'
+import { useEffect } from 'react'
+
+export default function Error({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string }
+  reset: () => void
+}) {
+  useEffect(() => {
+    console.error(error)
+  }, [error])
+
+  return (
+    <div className='bg-gray flex min-h-screen flex-col items-center justify-start pt-32 text-center text-red'>
+      <h2 className='mb-4 text-4xl font-bold'>Something went wrong!</h2>
+      <p className='mb-8 text-red'>{error.message}</p>
+      <button
+        className='focus:shadow-outline transform rounded bg-red px-4 py-2 font-bold text-grey transition-colors duration-150 hover:bg-grey hover:text-red focus:outline-none'
+        onClick={() => reset()}
+      >
+        Try again
+      </button>
+    </div>
+  )
+}


### PR DESCRIPTION
`/beacon` and `/cryptopunks` are fetching data server side

|Before|After|
|---|---|
|![Screenshot from 2024-02-07 21-46-16](https://github.com/anonklub/anonklub/assets/38692952/1001066a-4034-4548-a21f-02c610516577)|![Screenshot from 2024-02-07 21-47-32](https://github.com/anonklub/anonklub/assets/38692952/d23ae89b-e053-4af2-a840-9aa0dad08dca)|

Fix #261 
