### PR TITLE
fix(ui): disable submit proof request button if warning not read yet

### DIFF
--- a/ui/src/components/SubmitProofRequest.tsx
+++ b/ui/src/components/SubmitProofRequest.tsx
@@ -38,7 +38,7 @@ export function SubmitProofRequest() {
                 </button>
               </Link>
             ) : (
-              <button className='btn btn-secondary'>
+              <button className='btn btn-secondary is-disabled'>
                 {NAVIGATION.SUBMIT_PROOF}
               </button>
             )}


### PR DESCRIPTION
# Related issue

- Resolve #358