### PR TITLE
feat: build `spartan-ecdsa-wasm` pkg with `--release` profile

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -34,3 +34,4 @@ commitlint.config.js
 .prettierignore
 
 *.rs
+*.toml

--- a/pkgs/merkle-tree-wasm/package.json
+++ b/pkgs/merkle-tree-wasm/package.json
@@ -26,7 +26,7 @@
     "dist/index.js"
   ],
   "scripts": {
-    "compile": "pnpm check-wasm-pack && pnpm clean && wasm-pack build . --target bundler --out-dir dist --out-name index --scope anonklub",
+    "compile": "pnpm check-wasm-pack && pnpm clean && wasm-pack build . --release --target bundler --out-dir dist --out-name index --scope anonklub",
     "clean": "rm -rf dist",
     "check-wasm-pack": "command -v wasm-pack >/dev/null 2>&1 || echo \"wasm-pack is not installed\"\n",
     "format.cargo": "cargo fmt -- --check",

--- a/pkgs/spartan-ecdsa-wasm/Cargo.toml
+++ b/pkgs/spartan-ecdsa-wasm/Cargo.toml
@@ -15,9 +15,7 @@ ark-secq256k1 = "0.4.0"
 ark-serialize = "0.4.2"
 ethers = "2.0.11"
 num-bigint = "0.4.4"
-sapir = { git = "https://github.com/personaelabs/sapir.git", features = [
-    "profiler",
-], branch = "main" }
+sapir = { git = "https://github.com/personaelabs/sapir.git", branch = "main" }
 wasm-bindgen = "0.2.89"
 web-sys = "0.3.66"
 merkle-tree-wasm = { path = "../merkle-tree-wasm" }

--- a/pkgs/spartan-ecdsa-wasm/package.json
+++ b/pkgs/spartan-ecdsa-wasm/package.json
@@ -29,7 +29,7 @@
     "sideEffects": "dist/index.js",
     "type": "module",
     "scripts": {
-        "compile": "pnpm check-wasm-pack && pnpm clean && wasm-pack build . --target bundler --out-dir dist --out-name index --scope anonklub",
+        "compile": "pnpm check-wasm-pack && pnpm clean && wasm-pack build . --release --target bundler --out-dir dist --out-name index --scope anonklub",
         "clean": "rm -rf dist",
         "check-wasm-pack": "command -v wasm-pack >/dev/null 2>&1 || echo \"wasm-pack is not installed\"\n",
         "format.cargo": "cargo fmt -- --check",

--- a/pkgs/spartan-ecdsa-wasm/src/lib.rs
+++ b/pkgs/spartan-ecdsa-wasm/src/lib.rs
@@ -43,7 +43,7 @@ pub fn prove_membership(
     msg_hash: &[u8],
     merkle_proof_bytes_serialized: &[u8],
 ) -> Vec<u8> {
-    console::log_1(&"Starting prove_membership".into());
+    // console::log_1(&"Starting prove_membership".into());
 
     let merkle_proof =
         MerkleProofBytes::deserialize_compressed(merkle_proof_bytes_serialized).unwrap();
@@ -52,7 +52,7 @@ pub fn prove_membership(
     assert!(merkle_proof.path_indices.len() == NUM_MERKLE_PROOFS * TREE_DEPTH * 32);
     assert!(merkle_proof.root.len() == NUM_MERKLE_PROOFS * 32);
 
-    console::log_1(&"Starting Deserialize the inputs".into());
+    // console::log_1(&"Starting Deserialize the inputs".into());
     // Deserialize the inputs
     let s = Fr::from(BigUint::from_bytes_be(s));
     let r = Fq::from(BigUint::from_bytes_be(r));
@@ -85,11 +85,11 @@ pub fn prove_membership(
         .map(|root| F::from(BigUint::from_bytes_be(root)))
         .collect::<Vec<F>>();
 
-    console::log_1(&"Starting computing the efficient ECDSA input".into());
+    // console::log_1(&"Starting computing the efficient ECDSA input".into());
     // Compute the efficient ECDSA input
     let (u, t) = efficient_ecdsa(msg_hash.clone(), r, is_y_odd);
 
-    console::log_1(&"Starting constructing the private input".into());
+    // console::log_1(&"Starting constructing the private input".into());
     // Construct the private input
     let mut priv_input = vec![];
 
@@ -102,21 +102,21 @@ pub fn prove_membership(
 
     priv_input.extend_from_slice(&s_bits);
 
-    console::log_1(&"Starting append the Merkle indices and siblings to the private input".into());
+    // console::log_1(&"Starting append the Merkle indices and siblings to the private input".into());
     // Append the Merkle indices and siblings to the private input
     for i in 0..NUM_MERKLE_PROOFS {
         priv_input.extend_from_slice(&merkle_indices[i * TREE_DEPTH..((i + 1) * TREE_DEPTH)]);
         priv_input.extend_from_slice(&merkle_siblings[i * TREE_DEPTH..((i + 1) * TREE_DEPTH)]);
     }
 
-    console::log_1(&"Starting converting the private input to bytes".into());
+    // console::log_1(&"Starting converting the private input to bytes".into());
     // Convert the private input to bytes
     let priv_input = priv_input
         .iter()
         .flat_map(|x| x.into_bigint().to_bytes_be())
         .collect::<Vec<u8>>();
 
-    console::log_1(&"Starting constructing the public input".into());
+    // console::log_1(&"Starting constructing the public input".into());
     // Construct the public input
     let mut pub_input = vec![
         to_cs_field(t.x),
@@ -125,7 +125,7 @@ pub fn prove_membership(
         to_cs_field(u.y),
     ];
 
-    console::log_1(&"Starting appending the Merkle roots to the public input".into());
+    // console::log_1(&"Starting appending the Merkle roots to the public input".into());
     // Append the Merkle roots to the public input
     for root in merkle_roots {
         pub_input.push(to_cs_field(root));
@@ -136,7 +136,7 @@ pub fn prove_membership(
         .flat_map(|x| x.into_bigint().to_bytes_be())
         .collect::<Vec<u8>>();
 
-    console::log_1(&"Starting generating the proof".into());
+    // console::log_1(&"Starting generating the proof".into());
     // Generate the proof
     let proof = prove(&pub_input, &priv_input);
 
@@ -147,7 +147,7 @@ pub fn prove_membership(
         msg_hash,
     };
 
-    console::log_1(&"Starting serializing the full proof".into());
+    // console::log_1(&"Starting serializing the full proof".into());
     // Serialize the full proof
     let mut membership_proof_bytes = Vec::new();
     membership_proof


### PR DESCRIPTION
# Description

This PR optimized the wasm generated package for production. 

Another related PR is that in the Sapir package: https://github.com/personaelabs/sapir/pull/1
And its for also removing this console log in the production as you see from the screenshot. 
![Screenshot_20240213_155840](https://github.com/anonklub/anonklub/assets/36774944/4a5780cd-4f2e-4114-aa45-5c342c82f951)


Therefore after merging this PR we need to publish new `@anonklub/spartan-ecdsa-wasm` and `@anonklub/merkle-tree-wasm` packages.  And then use them inside the workers