### PR TITLE
fix(query-api): handle dune out of credits error (#394)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,7 @@
 DUNE_API_KEY=get one at https://dune.com/docs/api/
 GRAPH_API_KEY=get one at https://thegraph.com/
 GOOGLE_CLOUD_PROJECT=
-GOOGLE_APPLICATION_CREDENTIALS=json string data (includes private key) of a service account that has access to bigquery
+GOOGLE_APPLICATION_CREDENTIALS_JSON_STR=json string data (includes private key) of a service account that has access to bigquery
 NEXT_PUBLIC_WALLET_CONNECT_PROJECT_ID=get at https://cloud.walletconnect.com/sign-up
 NEXT_PUBLIC_QUERY_API_URL=https://anonset.fly.dev
 NEXT_PUBLIC_VERIFIER_ADDRESS=0x893f293e3918a179bf87fb772206e9927db61b0c

--- a/.lintstagedrc.json
+++ b/.lintstagedrc.json
@@ -1,4 +1,6 @@
 {
-  "*": ["prettier --write --ignore-path .prettierignore"],
-  "**/*.{ts,js}": ["eslint"]
+  "**/*.{css,less,scss,html,graphql,json,js,jsx,md,ts,tsx,yml,yaml}": [
+    "prettier --write --ignore-path .prettierignore"
+  ],
+  "**/*.{js,jsx,ts,tsx}": ["eslint"]
 }

--- a/.prettierignore
+++ b/.prettierignore
@@ -27,12 +27,4 @@ contracts/out
 package.json
 
 target
-.husky/*
 commitlint.config.js
-.eslint
-.eslintignore
-.prettierignore
-
-*.rs
-*.toml
-Dockerfile

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,3 +1,4 @@
 flyctl 0.1.119
 nodejs 19.1.0
 rust 1.76.0
+gcloud 465.0.0

--- a/query-api/src/anonset.controller.ts
+++ b/query-api/src/anonset.controller.ts
@@ -1,5 +1,4 @@
-import { CacheInterceptor } from '@nestjs/cache-manager'
-import { Controller, Get, Query, UseInterceptors } from '@nestjs/common'
+import { Controller, Get, Query } from '@nestjs/common'
 import { ApiOperation, ApiTags } from '@nestjs/swagger'
 import { AnonsetService } from './anonset.service'
 import { AnonsetResponse } from './decorators/AnonsetResponse'
@@ -11,7 +10,6 @@ import {
 } from './dto'
 
 @Controller()
-@UseInterceptors(CacheInterceptor)
 export class AnonsetController {
   constructor(private readonly service: AnonsetService) {}
 

--- a/query-api/src/anonset.module.ts
+++ b/query-api/src/anonset.module.ts
@@ -1,5 +1,6 @@
-import { CacheModule } from '@nestjs/cache-manager'
+import { CacheInterceptor, CacheModule } from '@nestjs/cache-manager'
 import { Module } from '@nestjs/common'
+import { APP_INTERCEPTOR } from '@nestjs/core'
 import { AnonsetController } from './anonset.controller'
 import { AnonsetService } from './anonset.service'
 import {
@@ -22,6 +23,10 @@ const ONE_DAY = 60 * 60 * 24 * 1000
     GraphRepository,
     BigqueryClient,
     DuneClient,
+    {
+      provide: APP_INTERCEPTOR,
+      useClass: CacheInterceptor,
+    },
   ],
 })
 export class AnonsetModule {}

--- a/query-api/src/decorators/handle-dune-credits-error.ts
+++ b/query-api/src/decorators/handle-dune-credits-error.ts
@@ -1,0 +1,28 @@
+import { OutOfDuneCreditsException } from '../errors/out-of-dune-credits.exception'
+
+export function HandleDuneCreditsError() {
+  return function (
+    _target: any,
+    _propertyName: string,
+    descriptor: PropertyDescriptor,
+  ) {
+    const originalMethod = descriptor.value
+
+    descriptor.value = function (...args: any[]) {
+      const result = originalMethod.apply(this, args)
+      if (result instanceof Promise) {
+        return result.catch((error: Error) => {
+          if (
+            error.message.includes(
+              'api request would exceed your configured limits per billing cycle',
+            )
+          ) {
+            throw new OutOfDuneCreditsException()
+          }
+          throw error
+        })
+      }
+      return result
+    }
+  }
+}

--- a/query-api/src/errors/out-of-dune-credits.exception.ts
+++ b/query-api/src/errors/out-of-dune-credits.exception.ts
@@ -1,0 +1,7 @@
+import { HttpException, HttpStatus } from '@nestjs/common'
+
+export class OutOfDuneCreditsException extends HttpException {
+  constructor() {
+    super('Dune credits are out.', HttpStatus.TOO_MANY_REQUESTS)
+  }
+}

--- a/query-api/src/errors/out-of-dune-credits.filter.ts
+++ b/query-api/src/errors/out-of-dune-credits.filter.ts
@@ -1,0 +1,17 @@
+import { ArgumentsHost, Catch, ExceptionFilter } from '@nestjs/common'
+import { Response } from 'express'
+import { OutOfDuneCreditsException } from './out-of-dune-credits.exception'
+
+@Catch(OutOfDuneCreditsException)
+export class OutOfDuneCreditsFilter implements ExceptionFilter {
+  catch(exception: OutOfDuneCreditsException, host: ArgumentsHost) {
+    const ctx = host.switchToHttp()
+    const response = ctx.getResponse<Response>()
+    const status = exception.getStatus()
+
+    response.status(status).json({
+      message: 'Dune credits are out.',
+      statusCode: exception.getStatus(),
+    })
+  }
+}

--- a/query-api/src/index.ts
+++ b/query-api/src/index.ts
@@ -9,6 +9,7 @@ async function bootstrap() {
   // TODO: set more restrictive CORS policy
   const app = await NestFactory.create<NestExpressApplication>(AnonsetModule, {
     cors: true,
+    logger: ['error', 'warn', 'log', 'debug'],
   })
   app.useGlobalPipes(new ValidationPipe())
   app.useStaticAssets(join(__dirname, '..', 'public'))

--- a/query-api/src/repositories/bigquery-client.ts
+++ b/query-api/src/repositories/bigquery-client.ts
@@ -5,7 +5,7 @@ import { Injectable } from '@nestjs/common'
 export class BigqueryClient extends BigQuery {
   constructor() {
     const {
-      GOOGLE_APPLICATION_CREDENTIALS,
+      GOOGLE_APPLICATION_CREDENTIALS_JSON_STR,
       GOOGLE_CLOUD_PROJECT: projectId,
       NODE_ENV,
     } = process.env
@@ -16,12 +16,12 @@ export class BigqueryClient extends BigQuery {
         projectId: '',
       })
     } else {
-      if (GOOGLE_APPLICATION_CREDENTIALS === undefined)
+      if (GOOGLE_APPLICATION_CREDENTIALS_JSON_STR === undefined)
         throw new Error('missing google credentials')
       if (projectId === undefined) throw new Error('missing google project id')
 
       super({
-        credentials: JSON.parse(GOOGLE_APPLICATION_CREDENTIALS),
+        credentials: JSON.parse(GOOGLE_APPLICATION_CREDENTIALS_JSON_STR),
         projectId,
       })
     }


### PR DESCRIPTION
* add gcloud to `.tool-versions`

* refactor: define cache at module level

* feat: handle dune out of credit error with specific exception

And add more logs

* fix: use keyFile path instead of parsed json string to auth bitgquery requests

* Revert "fix: use keyFile path instead of parsed json string to auth bitgquery requests"

This reverts commit 75cd26ebe219bc88a7d5e97b770fbeb881f5ac0a.

* refactor: rename GOOGLE_APPLICATION_CREDENTIALS to GOOGLE_APPLICATION_CREDENTIALS_JSON_STR

GOOGLE_APPLICATION_CREDENTIALS is what `gcloud` CLI uses by default.
It expects a path, not a JSON string

* update .env.example

* fix .lintstagedrc

prettier should only be ran for files extension that it supports