### PR TITLE
chore: publish `akli`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -128,7 +128,7 @@ dependencies = [
  "env_logger",
  "indicatif",
  "log",
- "merkle-tree-wasm",
+ "merkle-tree-wasm 1.1.0 (git+https://github.com/anonklub/anonklub?rev=ad324b411870c64e54aa80333c10be1591e49e04)",
  "mockito",
  "predicates",
  "serde",
@@ -2947,7 +2947,7 @@ dependencies = [
  "csv",
  "hex",
  "num-bigint",
- "poseidon",
+ "poseidon 0.1.0 (git+https://github.com/personaelabs/poseidon)",
  "rayon",
  "serde",
  "serde_json",
@@ -2966,7 +2966,29 @@ dependencies = [
  "csv",
  "hex",
  "num-bigint",
- "poseidon",
+ "poseidon 0.1.0 (git+https://github.com/personaelabs/poseidon?rev=133d535faadac705480f2f08a0ba9f61adf0d2b8)",
+ "rayon",
+ "serde",
+ "serde_json",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "merkle-tree-wasm"
+version = "1.1.0"
+source = "git+https://github.com/anonklub/anonklub?rev=ad324b411870c64e54aa80333c10be1591e49e04#ad324b411870c64e54aa80333c10be1591e49e04"
+dependencies = [
+ "ark-ff 0.4.2",
+ "ark-secp256k1",
+ "ark-secq256k1",
+ "ark-serialize 0.4.2",
+ "ark-std 0.4.0",
+ "console_error_panic_hook",
+ "csv",
+ "hex",
+ "num-bigint",
+ "poseidon 0.1.0 (git+https://github.com/personaelabs/poseidon)",
  "rayon",
  "serde",
  "serde_json",
@@ -3493,6 +3515,16 @@ name = "portable-atomic"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7170ef9988bc169ba16dd36a7fa041e5c4cbeb6a35b76d4c03daded371eae7c0"
+
+[[package]]
+name = "poseidon"
+version = "0.1.0"
+source = "git+https://github.com/personaelabs/poseidon?rev=133d535faadac705480f2f08a0ba9f61adf0d2b8#133d535faadac705480f2f08a0ba9f61adf0d2b8"
+dependencies = [
+ "ark-ff 0.4.2",
+ "ark-serialize 0.4.2",
+ "tiny-keccak",
+]
 
 [[package]]
 name = "poseidon"
@@ -4135,7 +4167,7 @@ dependencies = [
  "merkle-tree",
  "merlin",
  "num-bigint",
- "poseidon",
+ "poseidon 0.1.0 (git+https://github.com/personaelabs/poseidon)",
  "rand 0.8.5",
  "tiny-keccak",
  "wasm-bindgen",
@@ -4508,7 +4540,7 @@ dependencies = [
  "ark-secq256k1",
  "ark-serialize 0.4.2",
  "ethers",
- "merkle-tree-wasm",
+ "merkle-tree-wasm 1.1.0",
  "num-bigint",
  "sapir",
  "wasm-bindgen",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -128,7 +128,7 @@ dependencies = [
  "env_logger",
  "indicatif",
  "log",
- "merkle-tree-wasm 1.1.0 (git+https://github.com/anonklub/anonklub?rev=ad324b411870c64e54aa80333c10be1591e49e04)",
+ "merkle-tree-wasm 1.1.0",
  "mockito",
  "predicates",
  "serde",
@@ -167,6 +167,17 @@ checksum = "8d58d9f5da7b40e9bfff0b7e7816700be4019db97d4b6359fe7f94a9e22e42ac"
 dependencies = [
  "arrayvec",
  "bytes 1.5.0",
+]
+
+[[package]]
+name = "anonklub-poseidon"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "966e25b7f6d469e54f2e7b3772c3a15c844309178a61a1531f3d7d3834868f42"
+dependencies = [
+ "ark-ff 0.4.2",
+ "ark-serialize 0.4.2",
+ "tiny-keccak",
 ]
 
 [[package]]
@@ -2947,31 +2958,10 @@ dependencies = [
  "csv",
  "hex",
  "num-bigint",
- "poseidon 0.1.0 (git+https://github.com/personaelabs/poseidon)",
+ "poseidon",
  "rayon",
  "serde",
  "serde_json",
-]
-
-[[package]]
-name = "merkle-tree-wasm"
-version = "1.1.0"
-dependencies = [
- "ark-ff 0.4.2",
- "ark-secp256k1",
- "ark-secq256k1",
- "ark-serialize 0.4.2",
- "ark-std 0.4.0",
- "console_error_panic_hook",
- "csv",
- "hex",
- "num-bigint",
- "poseidon 0.1.0 (git+https://github.com/personaelabs/poseidon?rev=133d535faadac705480f2f08a0ba9f61adf0d2b8)",
- "rayon",
- "serde",
- "serde_json",
- "wasm-bindgen",
- "web-sys",
 ]
 
 [[package]]
@@ -2988,7 +2978,28 @@ dependencies = [
  "csv",
  "hex",
  "num-bigint",
- "poseidon 0.1.0 (git+https://github.com/personaelabs/poseidon)",
+ "poseidon",
+ "rayon",
+ "serde",
+ "serde_json",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "merkle-tree-wasm"
+version = "1.1.1"
+dependencies = [
+ "anonklub-poseidon",
+ "ark-ff 0.4.2",
+ "ark-secp256k1",
+ "ark-secq256k1",
+ "ark-serialize 0.4.2",
+ "ark-std 0.4.0",
+ "console_error_panic_hook",
+ "csv",
+ "hex",
+ "num-bigint",
  "rayon",
  "serde",
  "serde_json",
@@ -3515,16 +3526,6 @@ name = "portable-atomic"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7170ef9988bc169ba16dd36a7fa041e5c4cbeb6a35b76d4c03daded371eae7c0"
-
-[[package]]
-name = "poseidon"
-version = "0.1.0"
-source = "git+https://github.com/personaelabs/poseidon?rev=133d535faadac705480f2f08a0ba9f61adf0d2b8#133d535faadac705480f2f08a0ba9f61adf0d2b8"
-dependencies = [
- "ark-ff 0.4.2",
- "ark-serialize 0.4.2",
- "tiny-keccak",
-]
 
 [[package]]
 name = "poseidon"
@@ -4167,7 +4168,7 @@ dependencies = [
  "merkle-tree",
  "merlin",
  "num-bigint",
- "poseidon 0.1.0 (git+https://github.com/personaelabs/poseidon)",
+ "poseidon",
  "rand 0.8.5",
  "tiny-keccak",
  "wasm-bindgen",
@@ -4540,7 +4541,7 @@ dependencies = [
  "ark-secq256k1",
  "ark-serialize 0.4.2",
  "ethers",
- "merkle-tree-wasm 1.1.0",
+ "merkle-tree-wasm 1.1.1",
  "num-bigint",
  "sapir",
  "wasm-bindgen",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -128,7 +128,7 @@ dependencies = [
  "env_logger",
  "indicatif",
  "log",
- "merkle-tree-wasm 1.1.0",
+ "merkle-tree-wasm",
  "mockito",
  "predicates",
  "serde",
@@ -2966,28 +2966,6 @@ dependencies = [
 
 [[package]]
 name = "merkle-tree-wasm"
-version = "1.1.0"
-source = "git+https://github.com/anonklub/anonklub?rev=ad324b411870c64e54aa80333c10be1591e49e04#ad324b411870c64e54aa80333c10be1591e49e04"
-dependencies = [
- "ark-ff 0.4.2",
- "ark-secp256k1",
- "ark-secq256k1",
- "ark-serialize 0.4.2",
- "ark-std 0.4.0",
- "console_error_panic_hook",
- "csv",
- "hex",
- "num-bigint",
- "poseidon",
- "rayon",
- "serde",
- "serde_json",
- "wasm-bindgen",
- "web-sys",
-]
-
-[[package]]
-name = "merkle-tree-wasm"
 version = "1.1.1"
 dependencies = [
  "anonklub-poseidon",
@@ -4541,7 +4519,7 @@ dependencies = [
  "ark-secq256k1",
  "ark-serialize 0.4.2",
  "ethers",
- "merkle-tree-wasm 1.1.1",
+ "merkle-tree-wasm",
  "num-bigint",
  "sapir",
  "wasm-bindgen",

--- a/pkgs/cli/Cargo.toml
+++ b/pkgs/cli/Cargo.toml
@@ -33,7 +33,7 @@ serde = "1.0.197"
 serde_json = "1.0.114"
 strum = { version = "0.26.2", features = ["derive"] }
 surf = "2.3.2"
-merkle-tree-wasm = { path = "../merkle-tree-wasm" }
+merkle-tree-wasm = { version = "1.1.0", git = "https://github.com/anonklub/anonklub", rev = "ad324b411870c64e54aa80333c10be1591e49e04" }
 [dev-dependencies]
 alloy-primitives = "0.6.4"
 assert_cmd = "2.0.14"

--- a/pkgs/cli/Cargo.toml
+++ b/pkgs/cli/Cargo.toml
@@ -28,12 +28,12 @@ derive_more = "0.99.17"
 env_logger = "0.11.2"
 indicatif = "0.17.8"
 log = "0.4.20"
+merkle-tree-wasm = { version = "1.1.1", path = "../merkle-tree-wasm" }
 mockito = "1.4.0"
 serde = "1.0.197"
 serde_json = "1.0.114"
 strum = { version = "0.26.2", features = ["derive"] }
 surf = "2.3.2"
-merkle-tree-wasm = { version = "1.1.0", git = "https://github.com/anonklub/anonklub", rev = "ad324b411870c64e54aa80333c10be1591e49e04" }
 [dev-dependencies]
 alloy-primitives = "0.6.4"
 assert_cmd = "2.0.14"

--- a/pkgs/merkle-tree-wasm/Cargo.toml
+++ b/pkgs/merkle-tree-wasm/Cargo.toml
@@ -2,6 +2,7 @@
 name = "merkle-tree-wasm"
 version = "1.1.1"
 edition = "2021"
+license = "AGPL-3.0"
 authors = ["0xisk", "sripwoud"]
 repository = "https://github.com/anonklub/anonklub/tree/main/pkgs/merkle-tree-wasm"
 description = "Creation and management of Merkle tree structures."

--- a/pkgs/merkle-tree-wasm/Cargo.toml
+++ b/pkgs/merkle-tree-wasm/Cargo.toml
@@ -17,7 +17,7 @@ console_error_panic_hook = "0.1.7"
 csv = "1.3.0"
 hex = "0.4.3"
 num-bigint = "0.4.4"
-poseidon = { git = "https://github.com/personaelabs/poseidon" }
+poseidon = { git = "https://github.com/personaelabs/poseidon", rev = "133d535faadac705480f2f08a0ba9f61adf0d2b8" }
 rayon = "1.8.0"
 serde = { version = "1.0.188", features = ["derive"] }
 serde_json = "1.0.107"

--- a/pkgs/merkle-tree-wasm/Cargo.toml
+++ b/pkgs/merkle-tree-wasm/Cargo.toml
@@ -1,13 +1,17 @@
 [package]
 name = "merkle-tree-wasm"
-version = "1.1.0"
+version = "1.1.1"
 edition = "2021"
+authors = ["0xisk", "sripwoud"]
+repository = "https://github.com/anonklub/anonklub/tree/main/pkgs/merkle-tree-wasm"
+description = "Creation and management of Merkle tree structures."
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [lib]
 crate-type = ["lib","cdylib"]
 
 [dependencies]
+anonklub-poseidon = "1.0.0"
 ark-ff = "0.4.2"
 ark-secp256k1 = "0.4.0"
 ark-secq256k1 = "0.4.0"
@@ -17,7 +21,6 @@ console_error_panic_hook = "0.1.7"
 csv = "1.3.0"
 hex = "0.4.3"
 num-bigint = "0.4.4"
-poseidon = { git = "https://github.com/personaelabs/poseidon", rev = "133d535faadac705480f2f08a0ba9f61adf0d2b8" }
 rayon = "1.8.0"
 serde = { version = "1.0.188", features = ["derive"] }
 serde_json = "1.0.107"

--- a/pkgs/merkle-tree-wasm/src/lib.rs
+++ b/pkgs/merkle-tree-wasm/src/lib.rs
@@ -6,7 +6,7 @@ extern crate console_error_panic_hook;
 use ark_ff::{BigInteger, PrimeField};
 use ark_serialize::CanonicalSerialize;
 use num_bigint::BigUint;
-use poseidon::constants::secp256k1_w3;
+use anonklub_poseidon::constants::secp256k1_w3;
 use wasm_bindgen::{prelude::wasm_bindgen, JsValue};
 
 pub use merkle_tree_wasm::{MerkleProofBytes, MerkleTree};

--- a/pkgs/merkle-tree-wasm/src/lib.rs
+++ b/pkgs/merkle-tree-wasm/src/lib.rs
@@ -3,10 +3,10 @@ mod merkle_tree_wasm;
 
 extern crate console_error_panic_hook;
 
+use anonklub_poseidon::constants::secp256k1_w3;
 use ark_ff::{BigInteger, PrimeField};
 use ark_serialize::CanonicalSerialize;
 use num_bigint::BigUint;
-use anonklub_poseidon::constants::secp256k1_w3;
 use wasm_bindgen::{prelude::wasm_bindgen, JsValue};
 
 pub use merkle_tree_wasm::{MerkleProofBytes, MerkleTree};

--- a/pkgs/merkle-tree-wasm/src/merkle_tree_wasm.rs
+++ b/pkgs/merkle-tree-wasm/src/merkle_tree_wasm.rs
@@ -1,10 +1,10 @@
+use anonklub_poseidon::{Poseidon, PoseidonConstants};
 use ark_ff::PrimeField;
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
-use anonklub_poseidon::{Poseidon, PoseidonConstants};
 use rayon::{iter::ParallelIterator, slice::ParallelSlice};
 
-pub use ark_ff;
 pub use anonklub_poseidon;
+pub use ark_ff;
 
 pub struct MerkleTree<F: PrimeField, const WIDTH: usize> {
     _marker: std::marker::PhantomData<F>,

--- a/pkgs/merkle-tree-wasm/src/merkle_tree_wasm.rs
+++ b/pkgs/merkle-tree-wasm/src/merkle_tree_wasm.rs
@@ -1,10 +1,10 @@
 use ark_ff::PrimeField;
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
-use poseidon::{Poseidon, PoseidonConstants};
+use anonklub_poseidon::{Poseidon, PoseidonConstants};
 use rayon::{iter::ParallelIterator, slice::ParallelSlice};
 
 pub use ark_ff;
-pub use poseidon;
+pub use anonklub_poseidon;
 
 pub struct MerkleTree<F: PrimeField, const WIDTH: usize> {
     _marker: std::marker::PhantomData<F>,


### PR DESCRIPTION
### Publish `akli`.
We can't use unpublished deps when publishing a crate.  
So I forked https://github.com/personaelabs/poseidon --> https://github.com/anonklub/poseidon  
published it and used it as dep in `merkle-tree-wasm` instead of a `git` specified dep
then published `merkle-tree-wasm`
Use it as dep in `akli` instead of `git` specified dep.
