### PR TITLE
feat(akli): generate merkle root

### DIFF
--- a/pkgs/cli/README.md
+++ b/pkgs/cli/README.md
@@ -2,6 +2,8 @@
 
 Command line to interact with [anonklub query api](https://query.anonklub.xyz).
 
+## Examples
+
 - Query
 
   - ETH balance anonset
@@ -17,6 +19,11 @@ Command line to interact with [anonklub query api](https://query.anonklub.xyz).
   ```
 
 - Merkle
+  - Proof
   ```shell
-  cargo run --release -- merkle -f tests/fixtures/addresses.json -a 0x30b86f843a10ec6b28e8fa76b8b86d8317c708b6
+  cargo run --release -- merkle proof -f tests/fixtures/addresses.json -a 0x30b86f843a10ec6b28e8fa76b8b86d8317c708b6
+  ```
+  - Root
+  ```shell
+  cargo run --release merkle proof -f tests/fixtures/addresses.json
   ```

--- a/pkgs/cli/bin/main.rs
+++ b/pkgs/cli/bin/main.rs
@@ -7,7 +7,7 @@ use clap::Parser;
 use std::fmt::Write;
 
 pub mod opts;
-use merkle_tree_wasm::generate_merkle_proof;
+use merkle_tree_wasm::{generate_merkle_proof, generate_merkle_root};
 use opts::{Akli, AkliCommand, QuerySubcommand};
 
 use crate::opts::MerkleSubcommand;
@@ -53,8 +53,17 @@ async fn main() -> Result<()> {
                 });
                 println!("{}", merkle_proof_hex);
             }
-            MerkleSubcommand::Root { file } => {
-                println!("genera merkle root");
+            MerkleSubcommand::Root { file: anonset } => {
+                let merkle_root = generate_merkle_root(anonset.0, 15).map_err(|e| {
+                    anyhow::Error::msg(format!("Error generating merkle root: {:?}", e))
+                })?;
+
+                // TODO: extract in helper function
+                let merkle_root_hex = merkle_root.iter().fold(String::new(), |mut acc, x| {
+                    write!(acc, "{:02x}", x).expect("Failed to write string");
+                    acc
+                });
+                println!("{}", merkle_root_hex);
             }
         },
         AkliCommand::Prove {

--- a/pkgs/cli/bin/main.rs
+++ b/pkgs/cli/bin/main.rs
@@ -10,12 +10,14 @@ pub mod opts;
 use merkle_tree_wasm::generate_merkle_proof;
 use opts::{Akli, AkliCommand, QuerySubcommand};
 
+use crate::opts::MerkleSubcommand;
+
 #[async_std::main]
 async fn main() -> Result<()> {
     let Akli { cmd } = Akli::parse();
 
     match cmd {
-        AkliCommand::Query(query) => match query {
+        AkliCommand::Query(query_subcommand) => match query_subcommand {
             QuerySubcommand::Beacon => {
                 pprint(get_beacon_anonset().await);
             }
@@ -35,20 +37,26 @@ async fn main() -> Result<()> {
                 pprint(get_ens_dao_anonset(id, choice).await);
             }
         },
-        AkliCommand::Merkle {
-            file: anonset,
-            address,
-        } => {
-            let merkle_proof =
-                generate_merkle_proof(anonset.0, address.to_string().to_lowercase(), 15).map_err(
-                    |e| anyhow::Error::msg(format!("Error generating merkle proof: {:?}", e)),
-                )?;
-            let merkle_proof_hex = merkle_proof.iter().fold(String::new(), |mut acc, x| {
-                write!(acc, "{:02x}", x).expect("Failed to write string");
-                acc
-            });
-            println!("{}", merkle_proof_hex);
-        }
+        AkliCommand::Merkle(merkle_subcommand) => match merkle_subcommand {
+            MerkleSubcommand::Proof {
+                file: anonset,
+                address,
+            } => {
+                let merkle_proof =
+                    generate_merkle_proof(anonset.0, address.to_string().to_lowercase(), 15)
+                        .map_err(|e| {
+                            anyhow::Error::msg(format!("Error generating merkle proof: {:?}", e))
+                        })?;
+                let merkle_proof_hex = merkle_proof.iter().fold(String::new(), |mut acc, x| {
+                    write!(acc, "{:02x}", x).expect("Failed to write string");
+                    acc
+                });
+                println!("{}", merkle_proof_hex);
+            }
+            MerkleSubcommand::Root { file } => {
+                println!("genera merkle root");
+            }
+        },
         AkliCommand::Prove {
             merkle_root,
             message,

--- a/pkgs/cli/bin/opts.rs
+++ b/pkgs/cli/bin/opts.rs
@@ -16,19 +16,15 @@ pub struct Akli {
 
 #[derive(Debug, Subcommand)]
 pub enum AkliCommand {
+    /// Fetch anonymity sets
     #[clap(subcommand, name = "query")]
     Query(QuerySubcommand),
 
-    Merkle {
-        /// Path to the json file containing a list of addresses (aka Anonymity set)
-        #[clap(short, long, value_parser = parse_path)]
-        file: Anonset,
+    /// Generate a merkle proof or root
+    #[clap(subcommand, name = "merkle")]
+    Merkle(MerkleSubcommand),
 
-        /// Address you want to prove is in the set
-        #[clap(short, long, value_parser(|s: &str|s.parse::<Address>()))]
-        address: Address,
-    },
-
+    /// Build an ethereum address ownership zkp
     Prove {
         #[clap(short, long)]
         merkle_root: String,
@@ -40,6 +36,7 @@ pub enum AkliCommand {
         private_key: String,
     },
 
+    /// Verify an ethereum address ownership zkp
     #[clap(subcommand, name = "")]
     Verify,
 }
@@ -67,5 +64,26 @@ pub enum QuerySubcommand {
         id: String,
         #[clap(short, long)]
         choice: EnsVoteChoice,
+    },
+}
+
+#[derive(Debug, Subcommand)]
+pub enum MerkleSubcommand {
+    /// Generate a merkle proof
+    Proof {
+        /// Path to the json file containing a list of addresses (aka Anonymity set)
+        #[clap(short, long, value_parser = parse_path)]
+        file: Anonset,
+
+        /// Address you want to prove is in the set
+        #[clap(short, long, value_parser(|s: &str|s.parse::<Address>()))]
+        address: Address,
+    },
+
+    /// Generate a merkle root
+    Root {
+        #[clap(short, long, value_parser = parse_path)]
+        /// Path to the json file containing a list of addresses (aka Anonymity set)
+        file: Anonset,
     },
 }

--- a/pkgs/cli/tests/merkle.rs
+++ b/pkgs/cli/tests/merkle.rs
@@ -11,6 +11,7 @@ fn build_merkle_proof() -> Result<(), Box<dyn std::error::Error>> {
     let fixture_path = format!("{}/tests/fixtures/addresses.json", manifest_dir);
 
     cmd.arg("merkle")
+        .arg("proof")
         .arg("-f")
         .arg(fixture_path)
         .arg("-a")

--- a/pkgs/cli/tests/merkle.rs
+++ b/pkgs/cli/tests/merkle.rs
@@ -21,3 +21,18 @@ fn build_merkle_proof() -> Result<(), Box<dyn std::error::Error>> {
 
     Ok(())
 }
+
+#[test]
+pub fn build_merkle_root() -> Result<(), Box<dyn std::error::Error>> {
+    let mut cmd = Command::cargo_bin(BIN_NAME)?;
+    let manifest_dir = env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR is not set");
+    let fixture_path = format!("{}/tests/fixtures/addresses.json", manifest_dir);
+
+    cmd.arg("merkle").arg("root").arg("-f").arg(fixture_path);
+
+    cmd.assert().success().stdout(predicate::str::contains(
+        "e3bc08980139dddb41de1f4b64483840fe0ad54490cf0c916664d9447ed9bb46",
+    ));
+
+    Ok(())
+}

--- a/pkgs/merkle-tree-wasm/src/lib.rs
+++ b/pkgs/merkle-tree-wasm/src/lib.rs
@@ -11,7 +11,7 @@ use wasm_bindgen::{prelude::wasm_bindgen, JsValue};
 
 pub use merkle_tree_wasm::{MerkleProofBytes, MerkleTree};
 
-fn _build_merlke_tree<F: PrimeField>(
+fn _build_merkle_tree<F: PrimeField>(
     leaves: Vec<String>,
     depth: usize,
 ) -> Result<MerkleTree<F, 3>, String> {
@@ -43,7 +43,7 @@ fn _generate_merkle_proof<F: PrimeField>(
     leaf: String,
     depth: usize,
 ) -> Result<MerkleProofBytes, String> {
-    let tree = _build_merlke_tree::<F>(leaves, depth)?;
+    let tree = _build_merkle_tree::<F>(leaves, depth)?;
 
     let leaf_hex = hex::decode(leaf.replace("0x", ""))
         .map_err(|e| format!("MerkleTree: Error decoding hex: {}", e))?;
@@ -130,7 +130,7 @@ pub fn generate_merkle_proof(
 pub fn generate_merkle_root(leaves: Vec<String>, depth: usize) -> Result<Vec<u8>, String> {
     type F = ark_secp256k1::Fq;
 
-    let tree = _build_merlke_tree::<F>(leaves, depth)?;
+    let tree = _build_merkle_tree::<F>(leaves, depth)?;
 
     let root_bytes = tree
         .root

--- a/pkgs/merkle-tree-wasm/src/lib.rs
+++ b/pkgs/merkle-tree-wasm/src/lib.rs
@@ -11,11 +11,10 @@ use wasm_bindgen::{prelude::wasm_bindgen, JsValue};
 
 pub use merkle_tree_wasm::{MerkleProofBytes, MerkleTree};
 
-fn internal_generate_merkle_proof<F: PrimeField>(
+fn _build_merlke_tree<F: PrimeField>(
     leaves: Vec<String>,
-    leaf: String,
     depth: usize,
-) -> Result<MerkleProofBytes, String> {
+) -> Result<MerkleTree<F, 3>, String> {
     let mut padded_leaves = leaves.clone();
     // Pad the leaves to equal the size of the tree
     // Needs to be an even string
@@ -36,6 +35,15 @@ fn internal_generate_merkle_proof<F: PrimeField>(
     }
 
     tree.finish();
+    Ok(tree)
+}
+
+fn _generate_merkle_proof<F: PrimeField>(
+    leaves: Vec<String>,
+    leaf: String,
+    depth: usize,
+) -> Result<MerkleProofBytes, String> {
+    let tree = _build_merlke_tree::<F>(leaves, depth)?;
 
     let leaf_hex = hex::decode(leaf.replace("0x", ""))
         .map_err(|e| format!("MerkleTree: Error decoding hex: {}", e))?;
@@ -74,6 +82,7 @@ fn internal_generate_merkle_proof<F: PrimeField>(
     })
 }
 
+// TODO: use depth as Option, default to 15?
 #[cfg(target_arch = "wasm32")]
 #[wasm_bindgen]
 pub fn generate_merkle_proof(
@@ -85,8 +94,8 @@ pub fn generate_merkle_proof(
 
     type F = ark_secp256k1::Fq;
 
-    let merkle_proof_bytes = internal_generate_merkle_proof::<F>(leaves, leaf, depth)
-        .map_err(|e| JsValue::from_str(&e))?;
+    let merkle_proof_bytes =
+        _generate_merkle_proof::<F>(leaves, leaf, depth).map_err(|e| JsValue::from_str(&e))?;
 
     // Serialize the full merkle proof
     let mut merkle_proof_bytes_serialized = Vec::new();
@@ -105,7 +114,7 @@ pub fn generate_merkle_proof(
 ) -> Result<Vec<u8>, String> {
     type F = ark_secp256k1::Fq;
 
-    let merkle_proof_bytes = internal_generate_merkle_proof::<F>(leaves, leaf, depth)?;
+    let merkle_proof_bytes = _generate_merkle_proof::<F>(leaves, leaf, depth)?;
 
     // Serialize the full merkle proof
     let mut merkle_proof_bytes_serialized = Vec::new();
@@ -116,4 +125,20 @@ pub fn generate_merkle_proof(
     Ok(merkle_proof_bytes_serialized)
 }
 
-// TODO: writing tests
+// TODO: use Option for depth, default to 15
+#[cfg(not(target_arch = "wasm32"))]
+pub fn generate_merkle_root(leaves: Vec<String>, depth: usize) -> Result<Vec<u8>, String> {
+    type F = ark_secp256k1::Fq;
+
+    let tree = _build_merlke_tree::<F>(leaves, depth)?;
+
+    let root_bytes = tree
+        .root
+        .ok_or("MerkleTree: Root is not available")?
+        .into_bigint()
+        .to_bytes_be();
+
+    Ok(root_bytes)
+}
+
+// TODO:tests

--- a/pkgs/merkle-tree-wasm/src/merkle_tree_wasm.rs
+++ b/pkgs/merkle-tree-wasm/src/merkle_tree_wasm.rs
@@ -178,8 +178,8 @@ impl<F: PrimeField, const WIDTH: usize> MerkleTree<F, WIDTH> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use ark_std::{end_timer, start_timer};
     use anonklub_poseidon::constants::secp256k1_w3;
+    use ark_std::{end_timer, start_timer};
 
     type F = ark_secp256k1::Fq;
 

--- a/pkgs/merkle-tree-wasm/src/merkle_tree_wasm.rs
+++ b/pkgs/merkle-tree-wasm/src/merkle_tree_wasm.rs
@@ -179,7 +179,7 @@ impl<F: PrimeField, const WIDTH: usize> MerkleTree<F, WIDTH> {
 mod tests {
     use super::*;
     use ark_std::{end_timer, start_timer};
-    use poseidon::constants::secp256k1_w3;
+    use anonklub_poseidon::constants::secp256k1_w3;
 
     type F = ark_secp256k1::Fq;
 


### PR DESCRIPTION
 Add `root` subcommand to cli. Fix #398 

## Test plan
- run unit tests:
  From root: `cargo nextest run` (may need to install [nextest](https://nexte.st/book/installing-from-source.html) first)
- manual: `cargo run --release -- merkle root -f pkgs/cli/tests/fixtures/addresses.json`