### PR TITLE
refactor: use `anyhow` to handle errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -120,7 +120,6 @@ dependencies = [
  "alloy-primitives",
  "anyhow",
  "assert_cmd",
- "assert_fs",
  "async-std",
  "clap",
  "clap-verbosity-flag",
@@ -463,21 +462,6 @@ dependencies = [
  "predicates-core",
  "predicates-tree",
  "wait-timeout",
-]
-
-[[package]]
-name = "assert_fs"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cd762e110c8ed629b11b6cde59458cc1c71de78ebbcc30099fc8e0403a2a2ec"
-dependencies = [
- "anstyle",
- "doc-comment",
- "globwalk",
- "predicates",
- "predicates-core",
- "predicates-tree",
- "tempfile",
 ]
 
 [[package]]
@@ -2290,30 +2274,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
-name = "globset"
-version = "0.4.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57da3b9b5b85bd66f31093f8c408b90a74431672542466497dcbdfdc02034be1"
-dependencies = [
- "aho-corasick",
- "bstr",
- "log",
- "regex-automata",
- "regex-syntax 0.8.2",
-]
-
-[[package]]
-name = "globwalk"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bf760ebf69878d9fd8f110c89703d90ce35095324d1f1edcb595c63945ee757"
-dependencies = [
- "bitflags 2.4.1",
- "ignore",
- "walkdir",
-]
-
-[[package]]
 name = "gloo-timers"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2563,22 +2523,6 @@ checksum = "634d9b1461af396cad843f47fdba5597a4f9e6ddd4bfb6ff5d85028c25cb12f6"
 dependencies = [
  "unicode-bidi",
  "unicode-normalization",
-]
-
-[[package]]
-name = "ignore"
-version = "0.4.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b46810df39e66e925525d6e38ce1e7f6e1d208f72dc39757880fcb66e2c58af1"
-dependencies = [
- "crossbeam-deque",
- "globset",
- "log",
- "memchr",
- "regex-automata",
- "same-file",
- "walkdir",
- "winapi-util",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -230,9 +230,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.80"
+version = "1.0.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ad32ce52e4161730f7098c077cd2ed6229b5804ccf99e5366be1ab72a98b4e1"
+checksum = "0952808a6c2afd1aa8947271f3a60f1a6763c7b912d210184c5149b5cf147247"
 
 [[package]]
 name = "ark-ec"
@@ -2969,6 +2969,7 @@ name = "merkle-tree-wasm"
 version = "1.1.1"
 dependencies = [
  "anonklub-poseidon",
+ "anyhow",
  "ark-ff 0.4.2",
  "ark-secp256k1",
  "ark-secq256k1",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "publish.pkgs": "pnpm build.pkgs && changeset version && changeset publish",
     "start.query-api": "pnpm --filter query-api start.dev",
     "start.ui":"pnpm --filter @anonklub/ui dev",
-    "test.cargo": "cargo nextest run",
+    "test.cargo": "cargo nextest run --workspace",
     "test": "turbo _test test.jest test.cargo",
     "test.watch": "jest --watch",
     "typecheck": "turbo typecheck",

--- a/pkgs/cli/Cargo.toml
+++ b/pkgs/cli/Cargo.toml
@@ -35,7 +35,5 @@ serde_json = "1.0.114"
 strum = { version = "0.26.2", features = ["derive"] }
 surf = "2.3.2"
 [dev-dependencies]
-alloy-primitives = "0.6.4"
 assert_cmd = "2.0.14"
-assert_fs = "1.1.1"
 predicates = "3.1.0"

--- a/pkgs/cli/bin/main.rs
+++ b/pkgs/cli/bin/main.rs
@@ -55,13 +55,10 @@ async fn main() -> Result<()> {
             message,
             private_key,
         } => {
-            println!("Prove");
-            println!("Merkle Root: {}", merkle_root);
-            println!("Message: {}", message);
-            println!("Private Key: {}", private_key);
+            println!("Not implemented");
         }
         AkliCommand::Verify => {
-            println!("Verify");
+            println!("Not implemented");
         }
     }
 

--- a/pkgs/cli/bin/main.rs
+++ b/pkgs/cli/bin/main.rs
@@ -1,10 +1,9 @@
 use akli::{
     get_beacon_anonset, get_ens_dao_anonset, get_erc20_anonset, get_eth_anonset, get_nft_anonset,
-    get_punks_anonset, pprint,
+    get_punks_anonset, hexlify, pprint,
 };
 use anyhow::Result;
 use clap::Parser;
-use std::fmt::Write;
 
 pub mod opts;
 use merkle_tree_wasm::{generate_merkle_proof, generate_merkle_root};
@@ -43,27 +42,12 @@ async fn main() -> Result<()> {
                 address,
             } => {
                 let merkle_proof =
-                    generate_merkle_proof(anonset.0, address.to_string().to_lowercase(), 15)
-                        .map_err(|e| {
-                            anyhow::Error::msg(format!("Error generating merkle proof: {:?}", e))
-                        })?;
-                let merkle_proof_hex = merkle_proof.iter().fold(String::new(), |mut acc, x| {
-                    write!(acc, "{:02x}", x).expect("Failed to write string");
-                    acc
-                });
-                println!("{}", merkle_proof_hex);
+                    generate_merkle_proof(anonset.0, address.to_string().to_lowercase(), 15)?;
+                println!("{}", hexlify(merkle_proof));
             }
             MerkleSubcommand::Root { file: anonset } => {
-                let merkle_root = generate_merkle_root(anonset.0, 15).map_err(|e| {
-                    anyhow::Error::msg(format!("Error generating merkle root: {:?}", e))
-                })?;
-
-                // TODO: extract in helper function
-                let merkle_root_hex = merkle_root.iter().fold(String::new(), |mut acc, x| {
-                    write!(acc, "{:02x}", x).expect("Failed to write string");
-                    acc
-                });
-                println!("{}", merkle_root_hex);
+                let merkle_root = generate_merkle_root(anonset.0, 15)?;
+                println!("{}", hexlify(merkle_root));
             }
         },
         AkliCommand::Prove {

--- a/pkgs/cli/src/lib.rs
+++ b/pkgs/cli/src/lib.rs
@@ -64,3 +64,10 @@ pub fn parse_path(s: &str) -> Result<Anonset> {
 
     anonset
 }
+
+pub fn hexlify(bytes: Vec<u8>) -> String {
+    bytes.iter().fold(String::new(), |mut acc, x| {
+        format!("{:02x}", x).chars().for_each(|c| acc.push(c));
+        acc
+    })
+}

--- a/pkgs/merkle-tree-wasm/Cargo.toml
+++ b/pkgs/merkle-tree-wasm/Cargo.toml
@@ -13,6 +13,7 @@ crate-type = ["lib","cdylib"]
 
 [dependencies]
 anonklub-poseidon = "1.0.0"
+anyhow = "1.0.81"
 ark-ff = "0.4.2"
 ark-secp256k1 = "0.4.0"
 ark-secq256k1 = "0.4.0"

--- a/pkgs/merkle-tree-wasm/src/lib.rs
+++ b/pkgs/merkle-tree-wasm/src/lib.rs
@@ -89,14 +89,14 @@ pub fn generate_merkle_proof(
 
     type F = ark_secp256k1::Fq;
 
-    let merkle_proof_bytes =
-        _generate_merkle_proof::<F>(leaves, leaf, depth).map_err(|_e|JsValue::from_str("Could not generate merkle proof"))?;
+    let merkle_proof_bytes = _generate_merkle_proof::<F>(leaves, leaf, depth)
+        .map_err(|_e| JsValue::from_str("Could not generate merkle proof"))?;
 
     // Serialize the full merkle proof
     let mut merkle_proof_bytes_serialized = Vec::new();
     merkle_proof_bytes
         .serialize_compressed(&mut merkle_proof_bytes_serialized)
-        .map_err(|_e|JsValue::from_str("Could not serialize merkle proof bytes"))?;
+        .map_err(|_e| JsValue::from_str("Could not serialize merkle proof bytes"))?;
 
     Ok(merkle_proof_bytes_serialized)
 }

--- a/pkgs/merkle-tree-wasm/src/lib.rs
+++ b/pkgs/merkle-tree-wasm/src/lib.rs
@@ -84,19 +84,19 @@ pub fn generate_merkle_proof(
     leaves: Vec<String>,
     leaf: String,
     depth: usize,
-) -> Result<Vec<u8>, JsValue> {
+) -> std::result::Result<Vec<u8>, JsValue> {
     std::panic::set_hook(Box::new(console_error_panic_hook::hook));
 
     type F = ark_secp256k1::Fq;
 
     let merkle_proof_bytes =
-        _generate_merkle_proof::<F>(leaves, leaf, depth).map_err(|e| JsValue::from_str(&e))?;
+        _generate_merkle_proof::<F>(leaves, leaf, depth).map_err(|_e|JsValue::from_str("Could not generate merkle proof"))?;
 
     // Serialize the full merkle proof
     let mut merkle_proof_bytes_serialized = Vec::new();
     merkle_proof_bytes
         .serialize_compressed(&mut merkle_proof_bytes_serialized)
-        .with_context(|_e| JsValue::from_str("could not serialize merkle proof bytes"))?;
+        .map_err(|_e|JsValue::from_str("Could not serialize merkle proof bytes"))?;
 
     Ok(merkle_proof_bytes_serialized)
 }

--- a/pkgs/merkle-tree-wasm/src/lib.rs
+++ b/pkgs/merkle-tree-wasm/src/lib.rs
@@ -12,19 +12,13 @@ use wasm_bindgen::{prelude::wasm_bindgen, JsValue};
 
 pub use merkle_tree_wasm::{MerkleProofBytes, MerkleTree};
 
-fn _build_merkle_tree<F: PrimeField>(
-    leaves: Vec<String>,
-    depth: usize,
-) -> Result<MerkleTree<F, 3>> {
+fn _build_merkle_tree<F: PrimeField>(leaves: Vec<String>, depth: usize) -> Result<MerkleTree<F>> {
     let mut padded_leaves = leaves.clone();
     // Pad the leaves to equal the size of the tree
     // Needs to be an even string
     padded_leaves.resize(1 << depth, "00".to_string());
 
-    const ARITY: usize = 2;
-    const WIDTH: usize = ARITY + 1;
-
-    let mut tree = MerkleTree::<F, WIDTH>::new(secp256k1_w3());
+    let mut tree = MerkleTree::<F>::new(secp256k1_w3());
 
     // Insert all the leaves into the tree
     for leaf in &padded_leaves {

--- a/pkgs/merkle-tree-wasm/src/merkle_tree_wasm.rs
+++ b/pkgs/merkle-tree-wasm/src/merkle_tree_wasm.rs
@@ -200,4 +200,29 @@ mod tests {
         let proof = tree.create_proof(leaves[0]).unwrap();
         assert!(tree.verify_proof(tree.root.unwrap(), &proof));
     }
+
+    #[test]
+    fn fail_to_build_proof_if_leaf_not_present() {
+        let mut tree = MerkleTree::<F>::new(secp256k1_w3());
+
+        let depth = 10;
+        let num_leaves = 1 << depth;
+        println!("num_leaves: {}", num_leaves);
+        let leaves = (0..num_leaves)
+            .map(|i| F::from(i as u32))
+            .collect::<Vec<F>>();
+
+        // Insert leaves
+        for leaf in leaves.iter() {
+            tree.insert(*leaf);
+        }
+        tree.finish();
+
+        let leaf = F::from(num_leaves + 1);
+        let proof = tree.create_proof(leaf);
+        match proof {
+            Err(e) => assert_eq!(e.to_string(), "merkle tree leaf not found"),
+            _ => panic!("expected error"),
+        }
+    }
 }

--- a/turbo.json
+++ b/turbo.json
@@ -102,7 +102,7 @@
       ]
     },
     "//#test.cargo": {
-      "inputs": ["pkgs/cli/**/*.rs"]
+      "inputs": ["pkgs/**/*.rs"]
     },
     "_test": {
       "cache": false,


### PR DESCRIPTION
- **refactor: define `hexlify` helper function**
- **chore: add "not implemented" prints for proof commands**
- **refactor: handle errors with `anyhow`**
- **refactor: do not make `WIDTH` a generic param of MerkleTree**
- **chore: update test.cargo script**
