### PR TITLE
chore: merge staging

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,8 +20,7 @@ MERKLE_ROOT=
 
 # secret seeded from one of discord secret to restrcit request to ui to the discord discord-bot
 # eg echo -n "$CLIENT_ID" | openssl dgst -sha256 -binary | openssl base64 | tr -d '/+=' | cut -c1-32
-export DISCORD_BOT_API_KEY=
-export AUTH_HEADER_NAME=X-API-Key
+DISCORD_BOT_API_KEY=
 
 # discord bot
 BOT_TOKEN=create an application at https://discord.com/developers/applications

--- a/discord-bot/Dockerfile
+++ b/discord-bot/Dockerfile
@@ -34,8 +34,8 @@ COPY --from=build /app/$DIR/node_modules ./$DIR/node_modules
 COPY --from=build /app/$DIR/package.json ./$DIR/
 COPY --from=build /app/$DIR/dist ./$DIR/dist
 
-ENV NODE_ENV production
-ENV NODE_PATH dist
+ENV NODE_ENV=production
+ENV NODE_PATH=dist
 WORKDIR /app/$DIR
 
 # https://snyk.io/blog/10-best-practices-to-containerize-nodejs-web-applications-with-docker/

--- a/discord-bot/Dockerfile
+++ b/discord-bot/Dockerfile
@@ -29,13 +29,11 @@ ARG DIR
 # FIX ME: fix mkdir access when running as non root user
 # https://github.com/nodejs/docker-node/issues/740
 #WORKDIR /home/node/app
-RUN set -x && ls .
 COPY --from=build /app/node_modules ./node_modules
 COPY --from=build /app/$DIR/node_modules ./$DIR/node_modules
 COPY --from=build /app/$DIR/package.json ./$DIR/
 COPY --from=build /app/$DIR/dist ./$DIR/dist
 
-ENV AUTH_HEADER_NAME X-API-Key
 ENV NODE_ENV production
 ENV NODE_PATH dist
 WORKDIR /app/$DIR

--- a/discord-bot/src/lib/config.ts
+++ b/discord-bot/src/lib/config.ts
@@ -22,7 +22,6 @@ interface Config {
 }
 
 const {
-  AUTH_HEADER_NAME,
   BOT_TOKEN,
   CLIENT_ID,
   DISCORD_BOT_API_KEY,
@@ -31,7 +30,6 @@ const {
   VERIFICATION_CHANNEL_ID,
   VERIFIED_ROLE_ID,
 } = process.env
-if (AUTH_HEADER_NAME === undefined) throw new Error('No AUTH_HEADER_NAME provided')
 if (BOT_TOKEN === undefined) throw new Error('No BOT_TOKEN provided')
 if (CLIENT_ID === undefined) throw new Error('No CLIENT_ID provided')
 if (DISCORD_BOT_API_KEY === undefined) throw new Error('No DISCORD_BOT_API_KEY provided')
@@ -42,7 +40,7 @@ if (VERIFIED_ROLE_ID === undefined) throw new Error('No VERIFIED_ROLE_ID provide
 
 export const config: Config = {
   auth: {
-    header: AUTH_HEADER_NAME,
+    header: 'X-API-Key',
     secret: DISCORD_BOT_API_KEY,
   },
   BOT_TOKEN,

--- a/query-api/Dockerfile
+++ b/query-api/Dockerfile
@@ -37,7 +37,7 @@ COPY --from=build /app/$DIR/node_modules ./$DIR/node_modules
 COPY --from=build /app/$DIR/dist ./$DIR/dist
 COPY --from=build /app/$DIR/public ./$DIR/public
 
-ENV NODE_ENV production
+ENV NODE_ENV=production
 #USER node
 EXPOSE 3000
 

--- a/ui/Dockerfile
+++ b/ui/Dockerfile
@@ -16,6 +16,9 @@ FROM deps as build
 
 COPY ui/ ./ui
 
+ARG NEXT_PUBLIC_QUERY_API_URL
+ARG NEXT_PUBLIC_WALLET_CONNECT_PROJECT_ID 15d4c21cb519a86d0a3cdf1114cc56ec
+
 RUN pnpm --filter @anonklub/ui build &&\
     rm -rf {./,ui}/node_modules &&\
     pnpm --filter @anonklub/ui i --prod
@@ -27,7 +30,6 @@ COPY --from=build /app/ui/node_modules ./ui/node_modules
 COPY --from=build /app/ui/.next ./ui/.next
 COPY --from=build /app/ui/public ./ui/public
 
-ENV NEXT_PUBLIC_WALLET_CONNECT_PROJECT_ID 15d4c21cb519a86d0a3cdf1114cc56ec
 ENV NEXT_TELEMETRY_DISABLED 1
 ENV NODE_ENV production
 

--- a/ui/Dockerfile
+++ b/ui/Dockerfile
@@ -16,7 +16,7 @@ FROM deps as build
 
 COPY ui/ ./ui
 
-RUN pnpm --filter @anonklub/ui build.ci  &&\
+RUN pnpm --filter @anonklub/ui build &&\
     rm -rf {./,ui}/node_modules &&\
     pnpm --filter @anonklub/ui i --prod
 
@@ -26,14 +26,10 @@ COPY --from=build /app/node_modules ./node_modules
 COPY --from=build /app/ui/node_modules ./ui/node_modules
 COPY --from=build /app/ui/.next ./ui/.next
 COPY --from=build /app/ui/public ./ui/public
-# Link wasm files to .next/server/static as webpack5 breaks dynamic imports
-# see https://github.com/vercel/next.js/issues/25852#issuecomment-1057059000
-RUN ln -s /app/ui/.next/server/chunks/static /app/ui/.next/server/static
 
-ENV AUTH_HEADER_NAME=X-API-Key
-ENV NEXT_PUBLIC_WALLET_CONNECT_PROJECT_ID=15d4c21cb519a86d0a3cdf1114cc56ec
-ENV NEXT_TELEMETRY_DISABLED=1
-ENV NODE_ENV=production
+ENV NEXT_PUBLIC_WALLET_CONNECT_PROJECT_ID 15d4c21cb519a86d0a3cdf1114cc56ec
+ENV NEXT_TELEMETRY_DISABLED 1
+ENV NODE_ENV production
 
 EXPOSE 3000
 

--- a/ui/Dockerfile
+++ b/ui/Dockerfile
@@ -17,7 +17,7 @@ FROM deps as build
 COPY ui/ ./ui
 
 ARG NEXT_PUBLIC_QUERY_API_URL
-ARG NEXT_PUBLIC_WALLET_CONNECT_PROJECT_ID 15d4c21cb519a86d0a3cdf1114cc56ec
+ARG NEXT_PUBLIC_WALLET_CONNECT_PROJECT_ID=15d4c21cb519a86d0a3cdf1114cc56ec
 
 RUN pnpm --filter @anonklub/ui build &&\
     rm -rf {./,ui}/node_modules &&\

--- a/ui/Dockerfile
+++ b/ui/Dockerfile
@@ -19,7 +19,7 @@ COPY ui/ ./ui
 ARG NEXT_PUBLIC_QUERY_API_URL
 ARG NEXT_PUBLIC_WALLET_CONNECT_PROJECT_ID=15d4c21cb519a86d0a3cdf1114cc56ec
 
-RUN pnpm --filter @anonklub/ui build &&\
+RUN pnpm --filter @anonklub/ui build.ci &&\
     rm -rf {./,ui}/node_modules &&\
     pnpm --filter @anonklub/ui i --prod
 
@@ -29,6 +29,9 @@ COPY --from=build /app/node_modules ./node_modules
 COPY --from=build /app/ui/node_modules ./ui/node_modules
 COPY --from=build /app/ui/.next ./ui/.next
 COPY --from=build /app/ui/public ./ui/public
+# Link wasm files to .next/server/static as webpack5 breaks dynamic imports
+# see https://github.com/vercel/next.js/issues/25852#issuecomment-1057059000
+RUN ln -s /app/ui/.next/server/chunks/static /app/ui/.next/server/static
 
 ENV NEXT_TELEMETRY_DISABLED=1
 ENV NODE_ENV=production

--- a/ui/Dockerfile
+++ b/ui/Dockerfile
@@ -30,8 +30,8 @@ COPY --from=build /app/ui/node_modules ./ui/node_modules
 COPY --from=build /app/ui/.next ./ui/.next
 COPY --from=build /app/ui/public ./ui/public
 
-ENV NEXT_TELEMETRY_DISABLED 1
-ENV NODE_ENV production
+ENV NEXT_TELEMETRY_DISABLED=1
+ENV NODE_ENV=production
 
 EXPOSE 3000
 

--- a/ui/fly-prod.toml
+++ b/ui/fly-prod.toml
@@ -6,7 +6,7 @@ processes = []
 [build]
 build-target = "deploy"
 
-[env]
+[build.args]
 NEXT_PUBLIC_QUERY_API_URL = 'https://query.anonklub.xyz'
 
 [experimental]

--- a/ui/fly-staging.toml
+++ b/ui/fly-staging.toml
@@ -6,7 +6,7 @@ processes = []
 [build]
 build-target = "deploy"
 
-[env]
+[build.args]
 NEXT_PUBLIC_QUERY_API_URL = 'https://anonset-staging.fly.dev'
 
 [experimental]

--- a/ui/next.config.mjs
+++ b/ui/next.config.mjs
@@ -6,14 +6,14 @@ const nextConfig = {
     ignoreDuringBuilds: true,
   },
   reactStrictMode: true,
-  // TODO: instead on soft linking files with a script and Dockerfile, do like https://github.com/chungwu/combat-lander/commit/a22a0d2b302b623696b3e95d85566d3a7f1f6e3b
-  webpack: (config, options) => {
-    if (!options.isServer) {
-      config.resolve.fallback.fs = false
-      config.resolve.fallback.readline = false
-    }
+  // https://github.com/chungwu/combat-lander/commit/a22a0d2b302b623696b3e95d85566d3a7f1f6e3b
+  webpack: (config, { isServer }) => {
     config.experiments = { asyncWebAssembly: true, layers: true }
 
+    if (isServer)
+      config.output.webassemblyModuleFilename = './../static/wasm/[modulehash].wasm'
+    else
+      config.output.webassemblyModuleFilename = 'static/wasm/[modulehash].wasm'
     return config
   },
 }

--- a/ui/next.config.mjs
+++ b/ui/next.config.mjs
@@ -7,15 +7,10 @@ const nextConfig = {
   },
   reactStrictMode: true,
   // https://github.com/chungwu/combat-lander/commit/a22a0d2b302b623696b3e95d85566d3a7f1f6e3b
-  webpack: (config, { isServer }) => {
-    config.experiments = { asyncWebAssembly: true, layers: true }
-
-    if (isServer)
-      config.output.webassemblyModuleFilename = './../static/wasm/[modulehash].wasm'
-    else
-      config.output.webassemblyModuleFilename = 'static/wasm/[modulehash].wasm'
-    return config
-  },
+  webpack: (config, { isServer }) => ({
+    ...config,
+    experiments: { asyncWebAssembly: true, layers: true },
+  }),
 }
 
 const millionConfig = {

--- a/ui/package.json
+++ b/ui/package.json
@@ -44,10 +44,8 @@
     "pinojs": "^1.0.0"
   },
   "scripts": {
-    "build": "next build && pnpm linkwasm",
-    "build.ci": "next build",
+    "build": "next build",
     "dev": "next dev",
-    "linkwasm": "echo 'Linking wasm files to .next/server/static as webpack5 breaks dynamic imports, see https://github.com/vercel/next.js/issues/25852#issuecomment-1057059000' && ln -s $(pwd)/.next/server/{chunks/,}static",
     "start": "next start",
     "typecheck": "tsc"
   },

--- a/ui/package.json
+++ b/ui/package.json
@@ -44,8 +44,10 @@
     "pinojs": "^1.0.0"
   },
   "scripts": {
-    "build": "next build",
+    "build": "next build && pnpm linkwasm",
+    "build.ci": "next build",
     "dev": "next dev",
+    "linkwasm": "echo 'Linking wasm files to .next/server/static as webpack5 breaks dynamic imports, see https://github.com/vercel/next.js/issues/25852#issuecomment-1057059000' && ln -s $(pwd)/.next/server/{chunks/,}static",
     "start": "next start",
     "typecheck": "tsc"
   },

--- a/ui/src/app/api/verify/route.ts
+++ b/ui/src/app/api/verify/route.ts
@@ -1,12 +1,7 @@
 import { verifier } from '#/verifier'
 import { type NextRequest, NextResponse } from 'next/server'
 
-export const dynamic = 'force-dynamic'
-
 export async function POST(request: NextRequest) {
-  // TODO: add origin check in a middleware
-  // const origin = request.headers.get('origin')
-  // if (origin !== config.discordUrl) return NextResponse.error()
   const proof = new Uint8Array(await request.arrayBuffer())
   const result = await verifier.verifyMembership(proof)
   return NextResponse.json(result)

--- a/ui/src/app/query/asset/nft/punk/page.tsx
+++ b/ui/src/app/query/asset/nft/punk/page.tsx
@@ -3,6 +3,8 @@ import { config } from '#/config'
 import { getData } from '#/get-data'
 import { AnonSetResults } from '@components'
 
+export const dynamic = 'force-dynamic'
+
 export default async function Page() {
   const anonSet = await getData<string[]>(
     `${config.urls.queryApi}/asset/cryptopunk`,

--- a/ui/src/components/CheckMark.tsx
+++ b/ui/src/components/CheckMark.tsx
@@ -1,4 +1,4 @@
-import Image from 'next/image'
+import Image from 'next/legacy/image'
 
 export function CheckMark({
   full = false,

--- a/ui/src/components/Footer.tsx
+++ b/ui/src/components/Footer.tsx
@@ -1,4 +1,4 @@
-import Image from 'next/image'
+import Image from 'next/legacy/image'
 import { ExternalLink, Links } from './ExternalLink'
 
 export function Footer() {

--- a/ui/src/components/Header.tsx
+++ b/ui/src/components/Header.tsx
@@ -1,5 +1,5 @@
 'use client'
-import Image from 'next/image'
+import Image from 'next/legacy/image'
 import Link from 'next/link'
 import { ConnectButton } from './ConnectButton'
 import { HelpModal } from './HelpModal'

--- a/ui/src/lib/config.ts
+++ b/ui/src/lib/config.ts
@@ -18,29 +18,37 @@ interface Config {
   walletConnectProjectId: string
 }
 
-// need to use full reference to process.env, can't destructure or do process.env[name]
-// https://nextjs.org/docs/app/api-reference/next-config-js/env
-const AUTH_HEADER_NAME = process.env.AUTH_HEADER_NAME ?? ''
+const isClientSide = () => typeof window !== 'undefined'
+const isClientEnvVar = (key: string) => key.startsWith('NEXT_PUBLIC_')
+const isClientSideEnvVar = (key: string) => isClientEnvVar(key) && isClientSide()
+const isServerSideEnvVar = (key: string) => !isClientEnvVar(key) && !isClientSide()
+
+function isEnvVarDefined(key: string, value: unknown) {
+  if (
+    value === ''
+    && process.env.NEXT_PHASE !== PHASE_PRODUCTION_BUILD && (isClientSideEnvVar(key) || isServerSideEnvVar(key))
+  ) {
+    throw new Error(`Missing environment variable ${key}`)
+  }
+}
+
 const DISCORD_BOT_API_KEY = process.env.DISCORD_BOT_API_KEY ?? ''
-const NEXT_PUBLIC_QUERY_API_URL = process.env.NEXT_PUBLIC_QUERY_API_URL ?? ''
-const NEXT_PUBLIC_WALLET_CONNECT_PROJECT_ID = process.env.NEXT_PUBLIC_WALLET_CONNECT_PROJECT_ID ?? ''
+// do no destructure next public env vars or use variables to reference them
+// https://nextjs.org/docs/app/api-reference/next-config-js/env
 
 if (process.env.NEXT_PHASE !== PHASE_PRODUCTION_BUILD) {
   for (
     const [key, value] of Object.entries({
-      AUTH_HEADER_NAME,
       DISCORD_BOT_API_KEY,
-      NEXT_PUBLIC_QUERY_API_URL,
-      NEXT_PUBLIC_WALLET_CONNECT_PROJECT_ID,
+      NEXT_PUBLIC_QUERY_API_URL: process.env.NEXT_PUBLIC_QUERY_API_URL ?? '',
+      NEXT_PUBLIC_WALLET_CONNECT_PROJECT_ID: process.env.NEXT_PUBLIC_WALLET_CONNECT_PROJECT_ID ?? '',
     })
-  ) {
-    if (value === '') throw new Error(`Missing environment variable ${key}`)
-  }
+  ) { isEnvVarDefined(key, value) }
 }
 
 export const config: Config = {
   auth: {
-    header: AUTH_HEADER_NAME,
+    header: 'X-API-Key',
     secret: DISCORD_BOT_API_KEY,
   },
   appTitle: 'Anonklub',
@@ -49,7 +57,9 @@ export const config: Config = {
   proofAttachmentName: 'anonklub-proof.bin',
   typebot: 'anonklub-feedback',
   urls: {
-    queryApi: NEXT_PUBLIC_QUERY_API_URL,
+    // @ts-expect-error already checked against undefined
+    queryApi: process.env.NEXT_PUBLIC_QUERY_API_URL,
   },
-  walletConnectProjectId: NEXT_PUBLIC_WALLET_CONNECT_PROJECT_ID,
+  // @ts-expect-error already checked against undefined
+  walletConnectProjectId: process.env.NEXT_PUBLIC_WALLET_CONNECT_PROJECT_ID,
 }

--- a/ui/src/lib/config.ts
+++ b/ui/src/lib/config.ts
@@ -33,15 +33,17 @@ function isEnvVarDefined(key: string, value: unknown) {
 }
 
 const DISCORD_BOT_API_KEY = process.env.DISCORD_BOT_API_KEY ?? ''
-// do no destructure next public env vars or use variables to reference them
+// do no destructure next public env vars
 // https://nextjs.org/docs/app/api-reference/next-config-js/env
+const NEXT_PUBLIC_QUERY_API_URL = process.env.NEXT_PUBLIC_QUERY_API_URL ?? ''
+const NEXT_PUBLIC_WALLET_CONNECT_PROJECT_ID = process.env.NEXT_PUBLIC_WALLET_CONNECT_PROJECT_ID ?? ''
 
 if (process.env.NEXT_PHASE !== PHASE_PRODUCTION_BUILD) {
   for (
     const [key, value] of Object.entries({
       DISCORD_BOT_API_KEY,
-      NEXT_PUBLIC_QUERY_API_URL: process.env.NEXT_PUBLIC_QUERY_API_URL ?? '',
-      NEXT_PUBLIC_WALLET_CONNECT_PROJECT_ID: process.env.NEXT_PUBLIC_WALLET_CONNECT_PROJECT_ID ?? '',
+      NEXT_PUBLIC_QUERY_API_URL,
+      NEXT_PUBLIC_WALLET_CONNECT_PROJECT_ID,
     })
   ) { isEnvVarDefined(key, value) }
 }
@@ -57,9 +59,7 @@ export const config: Config = {
   proofAttachmentName: 'anonklub-proof.bin',
   typebot: 'anonklub-feedback',
   urls: {
-    // @ts-expect-error already checked against undefined
-    queryApi: process.env.NEXT_PUBLIC_QUERY_API_URL,
+    queryApi: NEXT_PUBLIC_QUERY_API_URL,
   },
-  // @ts-expect-error already checked against undefined
-  walletConnectProjectId: process.env.NEXT_PUBLIC_WALLET_CONNECT_PROJECT_ID,
+  walletConnectProjectId: NEXT_PUBLIC_WALLET_CONNECT_PROJECT_ID,
 }

--- a/ui/src/lib/config.ts
+++ b/ui/src/lib/config.ts
@@ -26,7 +26,7 @@ const isServerSideEnvVar = (key: string) => !isClientEnvVar(key) && !isClientSid
 function isEnvVarDefined(key: string, value: unknown) {
   if (
     value === ''
-    && process.env.NEXT_PHASE !== PHASE_PRODUCTION_BUILD && (isClientSideEnvVar(key) || isServerSideEnvVar(key))
+    && (isClientSideEnvVar(key) || isServerSideEnvVar(key))
   ) {
     throw new Error(`Missing environment variable ${key}`)
   }


### PR DESCRIPTION
- refactor use of `ARG`/`ENV` in Dockerfile:
  - hardcode what is shared between staging and production in Dockefile
  - hardcode `AUTH_HEADER_NAME` in config file
- fix next warning: use `next/legacy/image` instead of `next/image`
- remove addressed TODOs
- refactor check of env var definition at ui runtime: differentiate env var for client vs server side
