### PR TITLE
revert: build `halo2-binary-merkle-tree`

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -10,7 +10,6 @@
   "ignore": [
     "@anonklub/query-api",
     "@anonklub/ui",
-    "@anonklub/halo2-binary-merkle-tree",
     "@anonklub/halo2-ecdsa",
     "@anonklub/halo2-eth-membership-worker"
   ]

--- a/.changeset/serious-flowers-own.md
+++ b/.changeset/serious-flowers-own.md
@@ -1,0 +1,5 @@
+---
+"@anonklub/halo2-binary-merkle-tree": minor
+---
+
+Initial version

--- a/pkgs/halo2-binary-merkle-tree/package.json
+++ b/pkgs/halo2-binary-merkle-tree/package.json
@@ -1,10 +1,35 @@
 {
   "name": "@anonklub/halo2-binary-merkle-tree",
-  "private": true,
+  "version": "0.0.1",
+  "author": "0xisk <0xisk@proton.me>",
+  "description": "A rust crate implements binary merkle tree using halo2 Secp256k1 F, and PSE poseidon.",
+  "keywords": [
+    "wasm",
+    "merkle-tree",
+    "Secp256k1",
+    "rust"
+  ],
+  "license": "MIT",
+  "repository": "https://github.com/anonklub/anonklub",
+  "homepage": "https://github.com/anonklub/anonklub",
+  "bugs": "https://github.com/anonklub/anonklub/issues",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": [
+    "dist/**/*.{js,ts,wasm}",
+    "README.md",
+    "CHANGELOG.md"
+  ],
+  "module": "dist/index.js",
+  "sideEffects": [
+    "dist/index.js"
+  ],
   "scripts": {
+    "compile": "rimraf dist && wasm-pack build . --release --target web --out-dir dist --out-name index --scope anonklub",
     "format.cargo": "cargo fmt -- --check",
     "format.cargo.fix": "cargo fmt",
     "lint.cargo": "cargo clippy",
-    "lint.cargo.fix": "cargo clippy --fix"
+    "lint.cargo.fix": "cargo clippy --fix",
+    "prepack": "pnpm compile"
   }
 }


### PR DESCRIPTION
I wrongly thought the binary merkle tree didn't have to be wrapped in wasm and a web worker package.
So I deleted the building scripts in `halo2-binary-merkle-tree` in https://github.com/anonklub/anonklub/pull/493  
This PR reverts that change
Meaning now this package can be built (and published). And the UI needs it