### PR TITLE
fix(halo2-eth-membership-worker): downgrade `viem` do `^1`

### DIFF
--- a/.changeset/famous-rice-teach.md
+++ b/.changeset/famous-rice-teach.md
@@ -1,0 +1,5 @@
+---
+"@anonklub/halo2-eth-membership-worker": patch
+---
+
+fix: downgrade `viem` to `^1`

--- a/pkgs/halo2-eth-membership-worker/package.json
+++ b/pkgs/halo2-eth-membership-worker/package.json
@@ -30,6 +30,6 @@
   "dependencies": {
     "@anonklub/halo2-eth-membership": "0.1.1",
     "comlink": "^4.4.1",
-    "viem": "^2.0.10"
+    "viem": "^1.21.4"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -157,8 +157,8 @@ importers:
         specifier: ^4.4.1
         version: 4.4.1
       viem:
-        specifier: ^2.0.10
-        version: 2.20.1(typescript@5.3.3)(zod@3.23.8)
+        specifier: ^1.21.4
+        version: 1.21.4(typescript@5.3.3)(zod@3.23.8)
 
   pkgs/halo2-wasm-ext: {}
 
@@ -205,7 +205,7 @@ importers:
     devDependencies:
       ts-node:
         specifier: ^10.9.1
-        version: 10.9.2(@swc/core@1.7.19)(@types/node@20.16.2)(typescript@5.2.2)
+        version: 10.9.2(@swc/core@1.7.19(@swc/helpers@0.5.2))(@types/node@20.16.2)(typescript@5.2.2)
       typescript:
         specifier: 5.2.2
         version: 5.2.2
@@ -367,7 +367,7 @@ importers:
         version: 2.1.5(react@18.2.0)
       '@typebot.io/js':
         specifier: ^0.2.41
-        version: 0.2.92(@types/react@18.3.4)(immer@10.1.1)(react-dom@18.2.0(react@18.2.0))(react-native@0.75.2(@babel/core@7.25.2)(@babel/preset-env@7.25.4(@babel/core@7.25.2))(@types/react@18.3.4)(encoding@0.1.13)(react@18.2.0)(typescript@5.3.3))(react@18.2.0)(scheduler@0.23.2)(slate-history@0.109.0(slate@0.103.0))(slate-hyperscript@0.100.0(slate@0.103.0))(slate-react@0.109.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(slate@0.103.0))(slate@0.103.0)
+        version: 0.2.92(@types/react@18.3.4)(immer@10.1.1)(react-dom@18.2.0(react@18.2.0))(react-native@0.75.2(@babel/core@7.25.2)(@babel/preset-env@7.25.4(@babel/core@7.25.2))(@types/react@18.3.4)(encoding@0.1.13)(react@18.2.0)(typescript@5.3.3))(react@18.2.0)(scheduler@0.24.0-canary-efb381bbf-20230505)(slate-history@0.109.0(slate@0.103.0))(slate-hyperscript@0.100.0(slate@0.103.0))(slate-react@0.109.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(slate@0.103.0))(slate@0.103.0)
       '@typebot.io/nextjs':
         specifier: ^0.2.41
         version: 0.2.92(next@14.1.0(@babel/core@7.25.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react@18.2.0)
@@ -2485,9 +2485,6 @@ packages:
   '@noble/curves@1.2.0':
     resolution: {integrity: sha512-oYclrNgRaM9SsBUBVbb8M6DTV7ZHRTKugureoYEncY5c65HOmRzvSiTE3y5CYaPYJA/GVkrhXEoF0M3Ya9PMnw==}
 
-  '@noble/curves@1.4.0':
-    resolution: {integrity: sha512-p+4cb332SFCrReJkCYe8Xzm0OWi4Jji5jVdIZRL/PmacmDkFNw6MrrV+gGpiPxLHbV+zKFRywUWbaseT+tZRXg==}
-
   '@noble/curves@1.4.2':
     resolution: {integrity: sha512-TavHr8qycMChk8UwMld0ZDRvatedkzWfH8IiaeGCfymOP5i0hSCozz9vHOL0nkwk7HRMlFnAiKpS2jrUmSybcw==}
 
@@ -3519,17 +3516,6 @@ packages:
     peerDependencies:
       typescript: '>=5.0.4'
       zod: ^3 >=3.19.1
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-      zod:
-        optional: true
-
-  abitype@1.0.5:
-    resolution: {integrity: sha512-YzDhti7cjlfaBhHutMaboYB21Ha3rXR9QTkNJFzYC4kC8YclaiwPBBBJY8ejFdu2wnJeZCVZSMlQJ7fi8S6hsw==}
-    peerDependencies:
-      typescript: '>=5.0.4'
-      zod: ^3 >=3.22.0
     peerDependenciesMeta:
       typescript:
         optional: true
@@ -5563,11 +5549,6 @@ packages:
 
   isows@1.0.3:
     resolution: {integrity: sha512-2cKei4vlmg2cxEjm3wVSqn8pcoRF/LX/wpifuuNquFO4SQmPwarClT+SUCA2lt+l581tTeZIPIZuIDo2jWN1fg==}
-    peerDependencies:
-      ws: '*'
-
-  isows@1.0.4:
-    resolution: {integrity: sha512-hEzjY+x9u9hPmBom9IIAqdJCwNLax+xrPb51vEPpERoFlIxgmZcHzsT5jKG06nvInKOBGvReAVz80Umed5CczQ==}
     peerDependencies:
       ws: '*'
 
@@ -8525,14 +8506,6 @@ packages:
       typescript:
         optional: true
 
-  viem@2.20.1:
-    resolution: {integrity: sha512-a/BSe25TSfkc423GTSKYl1O0ON2J5huoQeOLkylHT1WS8wh3JFqb8nfAq7vg+aZ+W06BCTn36bbi47yp4D92Cg==}
-    peerDependencies:
-      typescript: '>=5.0.4'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-
   vlq@1.0.1:
     resolution: {integrity: sha512-gQpnTgkubC6hQgdIcRdYGDSDc+SaujOdyesZQMv6JlfQee/9Mp0Qhnys6WxDWvQnL5WZdT7o2Ul187aSt0Rq+w==}
 
@@ -8582,9 +8555,6 @@ packages:
 
   web-worker@1.3.0:
     resolution: {integrity: sha512-BSR9wyRsy/KOValMgd5kMyr3JzpdeoR9KVId8u5GVlTTAtNChlsE4yTxeY7zMdNSyOmoKBv8NH2qeRY9Tg+IaA==}
-
-  webauthn-p256@0.0.5:
-    resolution: {integrity: sha512-drMGNWKdaixZNobeORVIqq7k5DsRC9FnG201K2QjeOoQLmtSDaSsVZdkg6n5jUALJKcAG++zBPJXmv6hy0nWFg==}
 
   webcrypto-core@1.8.0:
     resolution: {integrity: sha512-kR1UQNH8MD42CYuLzvibfakG5Ew5seG85dMMoAM/1LqvckxaF6pUiidLuraIu4V+YCIFabYecUZAW0TuxAoaqw==}
@@ -8714,18 +8684,6 @@ packages:
 
   ws@8.13.0:
     resolution: {integrity: sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==}
-    engines: {node: '>=10.0.0'}
-    peerDependencies:
-      bufferutil: ^4.0.1
-      utf-8-validate: '>=5.0.2'
-    peerDependenciesMeta:
-      bufferutil:
-        optional: true
-      utf-8-validate:
-        optional: true
-
-  ws@8.17.1:
-    resolution: {integrity: sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==}
     engines: {node: '>=10.0.0'}
     peerDependencies:
       bufferutil: ^4.0.1
@@ -12097,10 +12055,6 @@ snapshots:
     dependencies:
       '@noble/hashes': 1.3.2
 
-  '@noble/curves@1.4.0':
-    dependencies:
-      '@noble/hashes': 1.4.0
-
   '@noble/curves@1.4.2':
     dependencies:
       '@noble/hashes': 1.4.0
@@ -12645,7 +12599,7 @@ snapshots:
   '@scure/bip32@1.3.0':
     dependencies:
       '@noble/curves': 1.0.0
-      '@noble/hashes': 1.3.0
+      '@noble/hashes': 1.3.2
       '@scure/base': 1.1.7
 
   '@scure/bip32@1.3.2':
@@ -12656,13 +12610,13 @@ snapshots:
 
   '@scure/bip32@1.4.0':
     dependencies:
-      '@noble/curves': 1.4.0
+      '@noble/curves': 1.4.2
       '@noble/hashes': 1.4.0
       '@scure/base': 1.1.7
 
   '@scure/bip39@1.2.0':
     dependencies:
-      '@noble/hashes': 1.3.0
+      '@noble/hashes': 1.3.2
       '@scure/base': 1.1.7
 
   '@scure/bip39@1.2.1':
@@ -12887,10 +12841,10 @@ snapshots:
 
   '@tsconfig/node16@1.0.4': {}
 
-  '@typebot.io/js@0.2.92(@types/react@18.3.4)(immer@10.1.1)(react-dom@18.2.0(react@18.2.0))(react-native@0.75.2(@babel/core@7.25.2)(@babel/preset-env@7.25.4(@babel/core@7.25.2))(@types/react@18.3.4)(encoding@0.1.13)(react@18.2.0)(typescript@5.3.3))(react@18.2.0)(scheduler@0.23.2)(slate-history@0.109.0(slate@0.103.0))(slate-hyperscript@0.100.0(slate@0.103.0))(slate-react@0.109.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(slate@0.103.0))(slate@0.103.0)':
+  '@typebot.io/js@0.2.92(@types/react@18.3.4)(immer@10.1.1)(react-dom@18.2.0(react@18.2.0))(react-native@0.75.2(@babel/core@7.25.2)(@babel/preset-env@7.25.4(@babel/core@7.25.2))(@types/react@18.3.4)(encoding@0.1.13)(react@18.2.0)(typescript@5.3.3))(react@18.2.0)(scheduler@0.24.0-canary-efb381bbf-20230505)(slate-history@0.109.0(slate@0.103.0))(slate-hyperscript@0.100.0(slate@0.103.0))(slate-react@0.109.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(slate@0.103.0))(slate@0.103.0)':
     dependencies:
       '@stripe/stripe-js': 1.54.1
-      '@udecode/plate-common': 30.4.5(@types/react@18.3.4)(immer@10.1.1)(react-dom@18.2.0(react@18.2.0))(react-native@0.75.2(@babel/core@7.25.2)(@babel/preset-env@7.25.4(@babel/core@7.25.2))(@types/react@18.3.4)(encoding@0.1.13)(react@18.2.0)(typescript@5.3.3))(react@18.2.0)(scheduler@0.23.2)(slate-history@0.109.0(slate@0.103.0))(slate-hyperscript@0.100.0(slate@0.103.0))(slate-react@0.109.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(slate@0.103.0))(slate@0.103.0)
+      '@udecode/plate-common': 30.4.5(@types/react@18.3.4)(immer@10.1.1)(react-dom@18.2.0(react@18.2.0))(react-native@0.75.2(@babel/core@7.25.2)(@babel/preset-env@7.25.4(@babel/core@7.25.2))(@types/react@18.3.4)(encoding@0.1.13)(react@18.2.0)(typescript@5.3.3))(react@18.2.0)(scheduler@0.24.0-canary-efb381bbf-20230505)(slate-history@0.109.0(slate@0.103.0))(slate-hyperscript@0.100.0(slate@0.103.0))(slate-react@0.109.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(slate@0.103.0))(slate@0.103.0)
       dompurify: 3.0.6
       ky: 1.2.4
       marked: 9.0.3
@@ -13096,10 +13050,10 @@ snapshots:
     dependencies:
       '@types/yargs-parser': 21.0.3
 
-  '@udecode/plate-common@30.4.5(@types/react@18.3.4)(immer@10.1.1)(react-dom@18.2.0(react@18.2.0))(react-native@0.75.2(@babel/core@7.25.2)(@babel/preset-env@7.25.4(@babel/core@7.25.2))(@types/react@18.3.4)(encoding@0.1.13)(react@18.2.0)(typescript@5.3.3))(react@18.2.0)(scheduler@0.23.2)(slate-history@0.109.0(slate@0.103.0))(slate-hyperscript@0.100.0(slate@0.103.0))(slate-react@0.109.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(slate@0.103.0))(slate@0.103.0)':
+  '@udecode/plate-common@30.4.5(@types/react@18.3.4)(immer@10.1.1)(react-dom@18.2.0(react@18.2.0))(react-native@0.75.2(@babel/core@7.25.2)(@babel/preset-env@7.25.4(@babel/core@7.25.2))(@types/react@18.3.4)(encoding@0.1.13)(react@18.2.0)(typescript@5.3.3))(react@18.2.0)(scheduler@0.24.0-canary-efb381bbf-20230505)(slate-history@0.109.0(slate@0.103.0))(slate-hyperscript@0.100.0(slate@0.103.0))(slate-react@0.109.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(slate@0.103.0))(slate@0.103.0)':
     dependencies:
-      '@udecode/plate-core': 30.4.5(@types/react@18.3.4)(immer@10.1.1)(react-dom@18.2.0(react@18.2.0))(react-native@0.75.2(@babel/core@7.25.2)(@babel/preset-env@7.25.4(@babel/core@7.25.2))(@types/react@18.3.4)(encoding@0.1.13)(react@18.2.0)(typescript@5.3.3))(react@18.2.0)(scheduler@0.23.2)(slate-history@0.109.0(slate@0.103.0))(slate-hyperscript@0.100.0(slate@0.103.0))(slate-react@0.109.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(slate@0.103.0))(slate@0.103.0)
-      '@udecode/plate-utils': 30.4.5(@types/react@18.3.4)(immer@10.1.1)(react-dom@18.2.0(react@18.2.0))(react-native@0.75.2(@babel/core@7.25.2)(@babel/preset-env@7.25.4(@babel/core@7.25.2))(@types/react@18.3.4)(encoding@0.1.13)(react@18.2.0)(typescript@5.3.3))(react@18.2.0)(scheduler@0.23.2)(slate-history@0.109.0(slate@0.103.0))(slate-hyperscript@0.100.0(slate@0.103.0))(slate-react@0.109.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(slate@0.103.0))(slate@0.103.0)
+      '@udecode/plate-core': 30.4.5(@types/react@18.3.4)(immer@10.1.1)(react-dom@18.2.0(react@18.2.0))(react-native@0.75.2(@babel/core@7.25.2)(@babel/preset-env@7.25.4(@babel/core@7.25.2))(@types/react@18.3.4)(encoding@0.1.13)(react@18.2.0)(typescript@5.3.3))(react@18.2.0)(scheduler@0.24.0-canary-efb381bbf-20230505)(slate-history@0.109.0(slate@0.103.0))(slate-hyperscript@0.100.0(slate@0.103.0))(slate-react@0.109.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(slate@0.103.0))(slate@0.103.0)
+      '@udecode/plate-utils': 30.4.5(@types/react@18.3.4)(immer@10.1.1)(react-dom@18.2.0(react@18.2.0))(react-native@0.75.2(@babel/core@7.25.2)(@babel/preset-env@7.25.4(@babel/core@7.25.2))(@types/react@18.3.4)(encoding@0.1.13)(react@18.2.0)(typescript@5.3.3))(react@18.2.0)(scheduler@0.24.0-canary-efb381bbf-20230505)(slate-history@0.109.0(slate@0.103.0))(slate-hyperscript@0.100.0(slate@0.103.0))(slate-react@0.109.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(slate@0.103.0))(slate@0.103.0)
       '@udecode/react-utils': 29.0.1(@types/react@18.3.4)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@udecode/slate': 25.0.0(slate-history@0.109.0(slate@0.103.0))(slate@0.103.0)
       '@udecode/slate-react': 29.0.1(@types/react@18.3.4)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(slate-history@0.109.0(slate@0.103.0))(slate-react@0.109.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(slate@0.103.0))(slate@0.103.0)
@@ -13117,7 +13071,7 @@ snapshots:
       - react-native
       - scheduler
 
-  '@udecode/plate-core@30.4.5(@types/react@18.3.4)(immer@10.1.1)(react-dom@18.2.0(react@18.2.0))(react-native@0.75.2(@babel/core@7.25.2)(@babel/preset-env@7.25.4(@babel/core@7.25.2))(@types/react@18.3.4)(encoding@0.1.13)(react@18.2.0)(typescript@5.3.3))(react@18.2.0)(scheduler@0.23.2)(slate-history@0.109.0(slate@0.103.0))(slate-hyperscript@0.100.0(slate@0.103.0))(slate-react@0.109.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(slate@0.103.0))(slate@0.103.0)':
+  '@udecode/plate-core@30.4.5(@types/react@18.3.4)(immer@10.1.1)(react-dom@18.2.0(react@18.2.0))(react-native@0.75.2(@babel/core@7.25.2)(@babel/preset-env@7.25.4(@babel/core@7.25.2))(@types/react@18.3.4)(encoding@0.1.13)(react@18.2.0)(typescript@5.3.3))(react@18.2.0)(scheduler@0.24.0-canary-efb381bbf-20230505)(slate-history@0.109.0(slate@0.103.0))(slate-hyperscript@0.100.0(slate@0.103.0))(slate-react@0.109.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(slate@0.103.0))(slate@0.103.0)':
     dependencies:
       '@udecode/slate': 25.0.0(slate-history@0.109.0(slate@0.103.0))(slate@0.103.0)
       '@udecode/slate-react': 29.0.1(@types/react@18.3.4)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(slate-history@0.109.0(slate@0.103.0))(slate-react@0.109.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(slate@0.103.0))(slate@0.103.0)
@@ -13140,16 +13094,16 @@ snapshots:
       slate-react: 0.109.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(slate@0.103.0)
       use-deep-compare: 1.3.0(react@18.2.0)
       zustand: 4.5.5(@types/react@18.3.4)(immer@10.1.1)(react@18.2.0)
-      zustand-x: 3.0.4(react-dom@18.2.0(react@18.2.0))(react-native@0.75.2(@babel/core@7.25.2)(@babel/preset-env@7.25.4(@babel/core@7.25.2))(@types/react@18.3.4)(encoding@0.1.13)(react@18.2.0)(typescript@5.3.3))(react@18.2.0)(scheduler@0.23.2)(zustand@4.5.5(@types/react@18.3.4)(immer@10.1.1)(react@18.2.0))
+      zustand-x: 3.0.4(react-dom@18.2.0(react@18.2.0))(react-native@0.75.2(@babel/core@7.25.2)(@babel/preset-env@7.25.4(@babel/core@7.25.2))(@types/react@18.3.4)(encoding@0.1.13)(react@18.2.0)(typescript@5.3.3))(react@18.2.0)(scheduler@0.24.0-canary-efb381bbf-20230505)(zustand@4.5.5(@types/react@18.3.4)(immer@10.1.1)(react@18.2.0))
     transitivePeerDependencies:
       - '@types/react'
       - immer
       - react-native
       - scheduler
 
-  '@udecode/plate-utils@30.4.5(@types/react@18.3.4)(immer@10.1.1)(react-dom@18.2.0(react@18.2.0))(react-native@0.75.2(@babel/core@7.25.2)(@babel/preset-env@7.25.4(@babel/core@7.25.2))(@types/react@18.3.4)(encoding@0.1.13)(react@18.2.0)(typescript@5.3.3))(react@18.2.0)(scheduler@0.23.2)(slate-history@0.109.0(slate@0.103.0))(slate-hyperscript@0.100.0(slate@0.103.0))(slate-react@0.109.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(slate@0.103.0))(slate@0.103.0)':
+  '@udecode/plate-utils@30.4.5(@types/react@18.3.4)(immer@10.1.1)(react-dom@18.2.0(react@18.2.0))(react-native@0.75.2(@babel/core@7.25.2)(@babel/preset-env@7.25.4(@babel/core@7.25.2))(@types/react@18.3.4)(encoding@0.1.13)(react@18.2.0)(typescript@5.3.3))(react@18.2.0)(scheduler@0.24.0-canary-efb381bbf-20230505)(slate-history@0.109.0(slate@0.103.0))(slate-hyperscript@0.100.0(slate@0.103.0))(slate-react@0.109.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(slate@0.103.0))(slate@0.103.0)':
     dependencies:
-      '@udecode/plate-core': 30.4.5(@types/react@18.3.4)(immer@10.1.1)(react-dom@18.2.0(react@18.2.0))(react-native@0.75.2(@babel/core@7.25.2)(@babel/preset-env@7.25.4(@babel/core@7.25.2))(@types/react@18.3.4)(encoding@0.1.13)(react@18.2.0)(typescript@5.3.3))(react@18.2.0)(scheduler@0.23.2)(slate-history@0.109.0(slate@0.103.0))(slate-hyperscript@0.100.0(slate@0.103.0))(slate-react@0.109.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(slate@0.103.0))(slate@0.103.0)
+      '@udecode/plate-core': 30.4.5(@types/react@18.3.4)(immer@10.1.1)(react-dom@18.2.0(react@18.2.0))(react-native@0.75.2(@babel/core@7.25.2)(@babel/preset-env@7.25.4(@babel/core@7.25.2))(@types/react@18.3.4)(encoding@0.1.13)(react@18.2.0)(typescript@5.3.3))(react@18.2.0)(scheduler@0.24.0-canary-efb381bbf-20230505)(slate-history@0.109.0(slate@0.103.0))(slate-hyperscript@0.100.0(slate@0.103.0))(slate-react@0.109.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(slate@0.103.0))(slate@0.103.0)
       '@udecode/react-utils': 29.0.1(@types/react@18.3.4)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@udecode/slate': 25.0.0(slate-history@0.109.0(slate@0.103.0))(slate@0.103.0)
       '@udecode/slate-react': 29.0.1(@types/react@18.3.4)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(slate-history@0.109.0(slate@0.103.0))(slate-react@0.109.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(slate@0.103.0))(slate@0.103.0)
@@ -13883,11 +13837,6 @@ snapshots:
       zod: 3.23.8
 
   abitype@0.9.8(typescript@5.3.3)(zod@3.23.8):
-    optionalDependencies:
-      typescript: 5.3.3
-      zod: 3.23.8
-
-  abitype@1.0.5(typescript@5.3.3)(zod@3.23.8):
     optionalDependencies:
       typescript: 5.3.3
       zod: 3.23.8
@@ -16221,10 +16170,6 @@ snapshots:
     dependencies:
       ws: 8.13.0
 
-  isows@1.0.4(ws@8.17.1):
-    dependencies:
-      ws: 8.17.1
-
   istanbul-lib-coverage@3.2.2: {}
 
   istanbul-lib-instrument@5.2.1:
@@ -18243,12 +18188,12 @@ snapshots:
 
   react-refresh@0.14.2: {}
 
-  react-tracked@1.7.14(react-dom@18.2.0(react@18.2.0))(react-native@0.75.2(@babel/core@7.25.2)(@babel/preset-env@7.25.4(@babel/core@7.25.2))(@types/react@18.3.4)(encoding@0.1.13)(react@18.2.0)(typescript@5.3.3))(react@18.2.0)(scheduler@0.23.2):
+  react-tracked@1.7.14(react-dom@18.2.0(react@18.2.0))(react-native@0.75.2(@babel/core@7.25.2)(@babel/preset-env@7.25.4(@babel/core@7.25.2))(@types/react@18.3.4)(encoding@0.1.13)(react@18.2.0)(typescript@5.3.3))(react@18.2.0)(scheduler@0.24.0-canary-efb381bbf-20230505):
     dependencies:
       proxy-compare: 2.6.0
       react: 18.2.0
-      scheduler: 0.23.2
-      use-context-selector: 1.4.4(react-dom@18.2.0(react@18.2.0))(react-native@0.75.2(@babel/core@7.25.2)(@babel/preset-env@7.25.4(@babel/core@7.25.2))(@types/react@18.3.4)(encoding@0.1.13)(react@18.2.0)(typescript@5.3.3))(react@18.2.0)(scheduler@0.23.2)
+      scheduler: 0.24.0-canary-efb381bbf-20230505
+      use-context-selector: 1.4.4(react-dom@18.2.0(react@18.2.0))(react-native@0.75.2(@babel/core@7.25.2)(@babel/preset-env@7.25.4(@babel/core@7.25.2))(@types/react@18.3.4)(encoding@0.1.13)(react@18.2.0)(typescript@5.3.3))(react@18.2.0)(scheduler@0.24.0-canary-efb381bbf-20230505)
     optionalDependencies:
       react-dom: 18.2.0(react@18.2.0)
       react-native: 0.75.2(@babel/core@7.25.2)(@babel/preset-env@7.25.4(@babel/core@7.25.2))(@types/react@18.3.4)(encoding@0.1.13)(react@18.2.0)(typescript@5.3.3)
@@ -19236,26 +19181,6 @@ snapshots:
     optionalDependencies:
       '@swc/core': 1.7.19(@swc/helpers@0.5.2)
 
-  ts-node@10.9.2(@swc/core@1.7.19)(@types/node@20.16.2)(typescript@5.2.2):
-    dependencies:
-      '@cspotcode/source-map-support': 0.8.1
-      '@tsconfig/node10': 1.0.11
-      '@tsconfig/node12': 1.0.11
-      '@tsconfig/node14': 1.0.3
-      '@tsconfig/node16': 1.0.4
-      '@types/node': 20.16.2
-      acorn: 8.12.1
-      acorn-walk: 8.3.3
-      arg: 4.1.3
-      create-require: 1.1.1
-      diff: 4.0.2
-      make-error: 1.3.6
-      typescript: 5.2.2
-      v8-compile-cache-lib: 3.0.1
-      yn: 3.1.1
-    optionalDependencies:
-      '@swc/core': 1.7.19(@swc/helpers@0.5.2)
-
   ts-node@10.9.2(@swc/core@1.7.19)(@types/node@20.16.2)(typescript@5.3.3):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
@@ -19487,10 +19412,10 @@ snapshots:
 
   urlpattern-polyfill@8.0.2: {}
 
-  use-context-selector@1.4.4(react-dom@18.2.0(react@18.2.0))(react-native@0.75.2(@babel/core@7.25.2)(@babel/preset-env@7.25.4(@babel/core@7.25.2))(@types/react@18.3.4)(encoding@0.1.13)(react@18.2.0)(typescript@5.3.3))(react@18.2.0)(scheduler@0.23.2):
+  use-context-selector@1.4.4(react-dom@18.2.0(react@18.2.0))(react-native@0.75.2(@babel/core@7.25.2)(@babel/preset-env@7.25.4(@babel/core@7.25.2))(@types/react@18.3.4)(encoding@0.1.13)(react@18.2.0)(typescript@5.3.3))(react@18.2.0)(scheduler@0.24.0-canary-efb381bbf-20230505):
     dependencies:
       react: 18.2.0
-      scheduler: 0.23.2
+      scheduler: 0.24.0-canary-efb381bbf-20230505
     optionalDependencies:
       react-dom: 18.2.0(react@18.2.0)
       react-native: 0.75.2(@babel/core@7.25.2)(@babel/preset-env@7.25.4(@babel/core@7.25.2))(@types/react@18.3.4)(encoding@0.1.13)(react@18.2.0)(typescript@5.3.3)
@@ -19601,24 +19526,6 @@ snapshots:
       - utf-8-validate
       - zod
 
-  viem@2.20.1(typescript@5.3.3)(zod@3.23.8):
-    dependencies:
-      '@adraffy/ens-normalize': 1.10.0
-      '@noble/curves': 1.4.0
-      '@noble/hashes': 1.4.0
-      '@scure/bip32': 1.4.0
-      '@scure/bip39': 1.3.0
-      abitype: 1.0.5(typescript@5.3.3)(zod@3.23.8)
-      isows: 1.0.4(ws@8.17.1)
-      webauthn-p256: 0.0.5
-      ws: 8.17.1
-    optionalDependencies:
-      typescript: 5.3.3
-    transitivePeerDependencies:
-      - bufferutil
-      - utf-8-validate
-      - zod
-
   vlq@1.0.1: {}
 
   wagmi@1.0.5(@types/react@18.3.4)(encoding@0.1.13)(immer@10.1.1)(react-dom@18.2.0(react@18.2.0))(react-native@0.75.2(@babel/core@7.25.2)(@babel/preset-env@7.25.4(@babel/core@7.25.2))(@types/react@18.3.4)(encoding@0.1.13)(react@18.2.0)(typescript@5.3.3))(react@18.2.0)(typescript@5.3.3)(viem@0.3.27(typescript@5.3.3)(zod@3.23.8))(zod@3.23.8):
@@ -19695,11 +19602,6 @@ snapshots:
   web-worker@1.2.0: {}
 
   web-worker@1.3.0: {}
-
-  webauthn-p256@0.0.5:
-    dependencies:
-      '@noble/curves': 1.4.0
-      '@noble/hashes': 1.4.0
 
   webcrypto-core@1.8.0:
     dependencies:
@@ -19823,8 +19725,6 @@ snapshots:
 
   ws@8.13.0: {}
 
-  ws@8.17.1: {}
-
   ws@8.18.0: {}
 
   xtend@4.0.2: {}
@@ -19886,11 +19786,11 @@ snapshots:
 
   zod@3.23.8: {}
 
-  zustand-x@3.0.4(react-dom@18.2.0(react@18.2.0))(react-native@0.75.2(@babel/core@7.25.2)(@babel/preset-env@7.25.4(@babel/core@7.25.2))(@types/react@18.3.4)(encoding@0.1.13)(react@18.2.0)(typescript@5.3.3))(react@18.2.0)(scheduler@0.23.2)(zustand@4.5.5(@types/react@18.3.4)(immer@10.1.1)(react@18.2.0)):
+  zustand-x@3.0.4(react-dom@18.2.0(react@18.2.0))(react-native@0.75.2(@babel/core@7.25.2)(@babel/preset-env@7.25.4(@babel/core@7.25.2))(@types/react@18.3.4)(encoding@0.1.13)(react@18.2.0)(typescript@5.3.3))(react@18.2.0)(scheduler@0.24.0-canary-efb381bbf-20230505)(zustand@4.5.5(@types/react@18.3.4)(immer@10.1.1)(react@18.2.0)):
     dependencies:
       immer: 10.1.1
       lodash.mapvalues: 4.6.0
-      react-tracked: 1.7.14(react-dom@18.2.0(react@18.2.0))(react-native@0.75.2(@babel/core@7.25.2)(@babel/preset-env@7.25.4(@babel/core@7.25.2))(@types/react@18.3.4)(encoding@0.1.13)(react@18.2.0)(typescript@5.3.3))(react@18.2.0)(scheduler@0.23.2)
+      react-tracked: 1.7.14(react-dom@18.2.0(react@18.2.0))(react-native@0.75.2(@babel/core@7.25.2)(@babel/preset-env@7.25.4(@babel/core@7.25.2))(@types/react@18.3.4)(encoding@0.1.13)(react@18.2.0)(typescript@5.3.3))(react@18.2.0)(scheduler@0.24.0-canary-efb381bbf-20230505)
       zustand: 4.5.5(@types/react@18.3.4)(immer@10.1.1)(react@18.2.0)
     transitivePeerDependencies:
       - react


### PR DESCRIPTION
`hexToSignature` is deprecated in v2 and it breaks the types
https://github.com/anonklub/anonklub/actions/runs/10594098796/job/29356971936#step:9:802

This also made be realized that the CI should have detected this typescript compile error in #500 but it didn't because the typescript check (and lint) checks were missing in the CI. This was fixed by #510 

Note how [`typecheck` is now successful](https://github.com/anonklub/anonklub/actions/runs/10594712864/job/29358948675?pr=509)