### PR TITLE
refactor(halo2-eth-mship-worker): simplify verify fn signature

### DIFF
--- a/.changeset/lovely-knives-approve.md
+++ b/.changeset/lovely-knives-approve.md
@@ -1,0 +1,5 @@
+---
+"@anonklub/halo2-eth-membership-worker": minor
+---
+
+Use single positional argument for `verifyMembership` instead of object argument with one key

--- a/pkgs/halo2-eth-membership-worker/src/interface.ts
+++ b/pkgs/halo2-eth-membership-worker/src/interface.ts
@@ -19,9 +19,7 @@ export interface ProveInputs {
   merkleProofBytesSerialized: Uint8Array
 }
 
-export interface VerifyInputs {
-  membershipProofSerialized: Uint8Array
-}
+export type VerifyInputs = Uint8Array
 
 export type ProveMembershipFn = (
   proveInputs: ProveInputs,

--- a/pkgs/halo2-eth-membership-worker/src/worker.ts
+++ b/pkgs/halo2-eth-membership-worker/src/worker.ts
@@ -1,6 +1,6 @@
 import { expose } from 'comlink'
 import { hashMessage, hexToSignature } from 'viem'
-import type { IHalo2EthMembershipWasm, IHalo2EthMembershipWorker } from './interface'
+import type { IHalo2EthMembershipWasm, IHalo2EthMembershipWorker, VerifyInputs } from './interface'
 import { calculateSigRecovery, fetchKzgParams, hexToLittleEndianBytes } from './utils'
 
 let halo2EthMembershipWasm: IHalo2EthMembershipWasm
@@ -52,7 +52,10 @@ export const Halo2EthMembershipWorker: IHalo2EthMembershipWorker = {
     )
   },
 
-  async verifyMembership({ membershipProofSerialized }): Promise<boolean> {
+  async verifyMembership(membershipProofSerialized: VerifyInputs): Promise<boolean> {
+    // Please note that K = 15 only supported for now until benchmarking is finished
+    const params = await fetchKzgParams(15)
+
     return halo2EthMembershipWasm.verify_membership(
       membershipProofSerialized,
       params,

--- a/pkgs/halo2-eth-membership-worker/src/worker.ts
+++ b/pkgs/halo2-eth-membership-worker/src/worker.ts
@@ -19,8 +19,8 @@ export const Halo2EthMembershipWorker: IHalo2EthMembershipWorker = {
     const response = await fetch(wasmModuleUrl)
     const bufferSource = await response.arrayBuffer()
 
-    await halo2EthMembershipWasm.initSync(bufferSource)
-    await halo2EthMembershipWasm.initPanicHook()
+    halo2EthMembershipWasm.initSync(bufferSource)
+    halo2EthMembershipWasm.initPanicHook()
 
     if (!initialized) {
       const numThreads = navigator.hardwareConcurrency

--- a/pkgs/halo2-eth-membership-worker/src/worker.ts
+++ b/pkgs/halo2-eth-membership-worker/src/worker.ts
@@ -8,7 +8,6 @@ let initialized = false
 let params: Uint8Array
 
 export const Halo2EthMembershipWorker: IHalo2EthMembershipWorker = {
-  // eslint-disable-next-line @typescript-eslint/no-misused-promises
   async prepare() {
     halo2EthMembershipWasm = await import('@anonklub/halo2-eth-membership')
 

--- a/pkgs/halo2-eth-membership-worker/src/worker.ts
+++ b/pkgs/halo2-eth-membership-worker/src/worker.ts
@@ -34,7 +34,7 @@ export const Halo2EthMembershipWorker: IHalo2EthMembershipWorker = {
     }
   },
 
-  async proveMembership({ merkleProofBytesSerialized, message, sig }): Promise<Uint8Array> {
+  async proveMembership({ merkleProofBytesSerialized, message, sig }) {
     const { r, s, v } = hexToSignature(sig)
 
     const sBytes = hexToLittleEndianBytes(s, 32)
@@ -53,7 +53,7 @@ export const Halo2EthMembershipWorker: IHalo2EthMembershipWorker = {
     )
   },
 
-  async verifyMembership(membershipProofSerialized: VerifyInputs): Promise<boolean> {
+  async verifyMembership(membershipProofSerialized: VerifyInputs) {
     return halo2EthMembershipWasm.verify_membership(
       membershipProofSerialized,
       params,

--- a/pkgs/halo2-eth-membership-worker/src/worker.ts
+++ b/pkgs/halo2-eth-membership-worker/src/worker.ts
@@ -3,6 +3,9 @@ import { hashMessage, hexToSignature } from 'viem'
 import type { IHalo2EthMembershipWasm, IHalo2EthMembershipWorker, VerifyInputs } from './interface'
 import { calculateSigRecovery, fetchKzgParams, hexToLittleEndianBytes } from './utils'
 
+// Benchmarking showed that k = 14 offers the best performance
+const K = 14
+
 let halo2EthMembershipWasm: IHalo2EthMembershipWasm
 let initialized = false
 let params: Uint8Array
@@ -25,8 +28,7 @@ export const Halo2EthMembershipWorker: IHalo2EthMembershipWorker = {
       const numThreads = navigator.hardwareConcurrency
       await halo2EthMembershipWasm.initThreadPool(numThreads)
 
-      // Please note that K = 14 only supported for now until benchmarking is finished
-      params = await fetchKzgParams(14)
+      params = await fetchKzgParams(K)
 
       initialized = true
     }
@@ -52,9 +54,6 @@ export const Halo2EthMembershipWorker: IHalo2EthMembershipWorker = {
   },
 
   async verifyMembership(membershipProofSerialized: VerifyInputs): Promise<boolean> {
-    // Please note that K = 15 only supported for now until benchmarking is finished
-    const params = await fetchKzgParams(15)
-
     return halo2EthMembershipWasm.verify_membership(
       membershipProofSerialized,
       params,


### PR DESCRIPTION
Simplify signature of `verifyMembership` function of the `halo2-eth-membership-worker`: as we only have 1 argument, it is unnecessarily complex to use an object with one key instead of a single position arg.